### PR TITLE
initial implementation of transport layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ lightning-invoice = { version = "0.22" }
 lightning-net-tokio = { version = "0.0.114" }
 
 bitcoin = "0.29.2"
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,10 @@
+use bitcoin::secp256k1::PublicKey;
+
+pub trait EventHandler {
+	fn handle_event(&self, event: Event);
+}
+
+#[derive(Debug, Clone)]
+pub enum Event {
+	ListProtocols { counterparty_node_id: PublicKey, protocols: Vec<u16> },
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,15 @@
 //! # ldk-lsp-client
 //! Types and primitives to integrate a spec-compliant LSP with an LDK-based node.
 #![deny(missing_docs)]
-#![deny(broken_intra_doc_links)]
-#![deny(private_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
 #![allow(bare_trait_objects)]
 #![allow(ellipsis_inclusive_range_patterns)]
+#![allow(clippy::drop_non_drop)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod channel_request;
+mod events;
 mod jit_channel;
 mod transport;
+mod utils;

--- a/src/transport/jsonrpc.rs
+++ b/src/transport/jsonrpc.rs
@@ -1,0 +1,270 @@
+// This file is Copyright its original authors, visible in version contror
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Types and primitives for [JSON-RPC 2.0 specification](https://www.jsonrpc.org/specification).
+use std::{collections::HashMap, fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const VERSION: &str = "2.0";
+pub const INVALID_REQUEST_ERROR_CODE: i32 = -32600;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Method {
+	pub prefix: String,
+	pub name: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParseMethodError;
+
+impl Display for ParseMethodError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "invalid method format")
+	}
+}
+
+impl FromStr for Method {
+	type Err = ParseMethodError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		let mut split = s.split('.');
+		let prefix = split.next().ok_or(ParseMethodError)?.to_string();
+		let name = split.next().ok_or(ParseMethodError)?.to_string();
+		Ok(Method { prefix, name })
+	}
+}
+
+impl Display for Method {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}.{}", self.prefix, self.name)
+	}
+}
+
+impl Serialize for Method {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		serializer.serialize_str(&self.to_string())
+	}
+}
+
+// implement Deserialize for Method using it's FromStr implementation
+impl<'de> Deserialize<'de> for Method {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		let s = String::deserialize(deserializer)?;
+		Method::from_str(&s).map_err(serde::de::Error::custom)
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Error {
+	/// A number indicating the error type that occurred.
+	pub code: i32,
+	/// A string providing a short description of the error.
+	pub message: String,
+	/// A primitive or structured value that contains additional information about the error.
+	pub data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+/// A JSONRPC request object.
+pub struct Request {
+	/// The name of the RPC call.
+	pub method: Method,
+	/// Parameters to the RPC call.
+	/// Note: Only by-name parameters are allowed.
+	pub params: HashMap<String, Value>,
+	/// Identifier for this Request, which should appear in the response.
+	pub id: Value,
+	/// jsonrpc field, MUST be "2.0".
+	pub jsonrpc: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Notification {
+	/// The name of the RPC call.
+	pub method: Method,
+	/// Parameters to the RPC call.
+	pub params: HashMap<String, Value>,
+	/// jsonrpc field, MUST be "2.0".
+	pub jsonrpc: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(untagged)]
+/// A JSON-RPC 2.0 response object.
+pub enum Response {
+	/// A successful response.
+	Success(SuccessResponse),
+	/// An error response.
+	Error(ErrorResponse),
+}
+
+impl Response {
+	pub fn get_id(&self) -> &Value {
+		match self {
+			Response::Success(success) => &success.id,
+			Response::Error(error) => &error.id,
+		}
+	}
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+/// A JSON-RPC 2.0 error response object.
+pub struct ErrorResponse {
+	/// The error.
+	pub error: Error,
+	/// Identifier for this Request, which should match that of the request.
+	pub id: Value,
+	/// jsonrpc field, MUST be "2.0".
+	pub jsonrpc: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+/// A JSON-RPC 2.0 successful response object.
+pub struct SuccessResponse {
+	/// The result.
+	pub result: Value,
+	/// Identifier for this Request, which should match that of the request.
+	pub id: Value,
+	/// jsonrpc field, MUST be "2.0".
+	pub jsonrpc: String,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn deserializes_error_response() {
+		let json = r#"{
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": null
+        }"#;
+
+		let response: Response = serde_json::from_str(json).unwrap();
+		assert_eq!(
+			response,
+			Response::Error(ErrorResponse {
+				error: Error { code: -32600, message: "Invalid Request".to_string(), data: None },
+				id: serde_json::Value::Null,
+				jsonrpc: "2.0".to_string(),
+			})
+		);
+	}
+
+	#[test]
+	fn deserializes_success_response() {
+		let json = r#"{
+            "jsonrpc": "2.0",
+            "result": 5,
+            "id": "1"
+        }"#;
+
+		let response: Response = serde_json::from_str(json).unwrap();
+		assert_eq!(
+			response,
+			Response::Success(SuccessResponse {
+				result: json!(5),
+				id: json!("1"),
+				jsonrpc: "2.0".to_string(),
+			})
+		);
+	}
+
+	#[test]
+	fn fails_deserialize_with_both_error_result() {
+		let json = r#"{
+            "jsonrpc": "2.0",
+            "result": 5,
+            "error": {
+                "code": -32600,
+                "message": "Invalid Request"
+            },
+            "id": "1"
+        }"#;
+
+		let response: Result<Response, serde_json::Error> = serde_json::from_str(json);
+		assert!(response.is_err());
+	}
+
+	#[test]
+	fn serializes_error_response() {
+		let response = Response::Error(ErrorResponse {
+			error: Error { code: -32600, message: "Invalid Request".to_string(), data: None },
+			id: serde_json::Value::Null,
+			jsonrpc: "2.0".to_string(),
+		});
+
+		let json = serde_json::to_string(&response).unwrap();
+		assert_eq!(
+			json,
+			r#"{"error":{"code":-32600,"message":"Invalid Request","data":null},"id":null,"jsonrpc":"2.0"}"#
+		);
+	}
+
+	#[test]
+	fn serializes_success_response() {
+		let response = Response::Success(SuccessResponse {
+			result: json!(5),
+			id: json!("1"),
+			jsonrpc: "2.0".to_string(),
+		});
+
+		let json = serde_json::to_string(&response).unwrap();
+		assert_eq!(json, r#"{"result":5,"id":"1","jsonrpc":"2.0"}"#);
+	}
+
+	#[test]
+	fn deserializes_request_method() {
+		let json = r#"{
+			"jsonrpc": "2.0",
+			"method": "prefix.name",
+			"params": { "a": 5 },
+			"id": 3
+		}"#;
+
+		let request: Request = serde_json::from_str(json).unwrap();
+		assert_eq!(
+			request,
+			Request {
+				method: Method { prefix: "prefix".to_string(), name: "name".to_string() },
+				params: vec![("a".to_string(), json!(5)),].into_iter().collect(),
+				id: json!(3),
+				jsonrpc: "2.0".to_string(),
+			}
+		);
+	}
+
+	#[test]
+	fn serializes_request_method() {
+		let request = Request {
+			method: Method { prefix: "prefix".to_string(), name: "name".to_string() },
+			params: vec![("a".to_string(), json!(5))].into_iter().collect(),
+			id: json!(3),
+			jsonrpc: "2.0".to_string(),
+		};
+
+		let json = serde_json::to_string(&request).unwrap();
+		assert_eq!(json, r#"{"method":"prefix.name","params":{"a":5},"id":3,"jsonrpc":"2.0"}"#);
+	}
+}

--- a/src/transport/message_handler.rs
+++ b/src/transport/message_handler.rs
@@ -1,0 +1,298 @@
+use crate::events::{Event, EventHandler};
+use crate::transport::{jsonrpc, msgs};
+use crate::utils;
+use bitcoin::secp256k1::PublicKey;
+use lightning::chain::keysinterface::EntropySource;
+use lightning::{
+	ln::{peer_handler::CustomMessageHandler, wire::CustomMessageReader},
+	log_info,
+	util::logger::Logger,
+};
+use std::{collections::HashMap, io, ops::Deref, sync::Mutex};
+
+pub trait LSPMessageHandler {
+	fn handle_lsps_request(
+		&self, request: jsonrpc::Request, counterparty_node_id: &PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError>;
+	fn handle_lsps_response(
+		&self, request: jsonrpc::Request, response: jsonrpc::Response,
+		counterparty_node_id: &PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError>;
+	fn handle_lsps_notification(
+		&self, notification: jsonrpc::Notification, counterparty_node_id: &PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError>;
+	fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, msgs::RawLSPSMessage)>;
+	fn get_protocol_number(&self) -> u16;
+}
+
+pub struct LSPManager<LMH: Deref, L: Deref, ES: Deref>
+where
+	LMH::Target: LSPMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	pending_messages: Mutex<Vec<(PublicKey, msgs::RawLSPSMessage)>>,
+	pending_requests: Mutex<HashMap<String, jsonrpc::Request>>,
+	message_handlers: Mutex<HashMap<String, LMH>>,
+	pending_events: Mutex<Vec<Event>>,
+	logger: L,
+	entropy_source: ES,
+}
+
+impl<LMH: Deref, L: Deref, ES: Deref> LSPManager<LMH, L, ES>
+where
+	LMH::Target: LSPMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	pub fn new(logger: L, entropy_source: ES) -> Self {
+		Self {
+			pending_messages: Mutex::new(Vec::new()),
+			pending_requests: Mutex::new(HashMap::new()),
+			message_handlers: Mutex::new(HashMap::new()),
+			pending_events: Mutex::new(Vec::new()),
+			logger,
+			entropy_source,
+		}
+	}
+
+	pub fn generate_request_id(&self) -> String {
+		let bytes = self.entropy_source.get_secure_random_bytes();
+		utils::hex_str(&bytes[0..16])
+	}
+
+	pub fn register_message_handler(&self, prefix: String, message_handler: LMH) {
+		self.message_handlers.lock().unwrap().insert(prefix, message_handler);
+	}
+
+	pub fn list_protocols(
+		&self, counterparty_node_id: PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		let request = jsonrpc::Request {
+			jsonrpc: jsonrpc::VERSION.to_string(),
+			id: serde_json::Value::String(self.generate_request_id()),
+			method: jsonrpc::Method {
+				prefix: "lsps0".to_string(),
+				name: "listprotocols".to_string(),
+			},
+			params: HashMap::new(),
+		};
+
+		let msg = msgs::RawLSPSMessage { payload: serde_json::to_string(&request).unwrap() };
+
+		self.insert_pending_request(request);
+
+		self.enqueue_message(counterparty_node_id, msg);
+		Ok(())
+	}
+
+	pub fn process_pending_events<H: EventHandler>(&self, handler: H) {
+		let mut pending_events = self.pending_events.lock().unwrap();
+		pending_events.drain(..).for_each(|event| handler.handle_event(event));
+	}
+
+	fn handle_lsps_message(
+		&self, msg: msgs::LSPSMessage, sender_node_id: &PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		match msg {
+			msgs::LSPSMessage::Request(request) => {
+				if request.method.prefix == "lsps0" && request.method.name == "listprotocols" {
+					let mut protocols = vec![];
+					let message_handlers = self.message_handlers.lock().unwrap();
+					for message_handler in message_handlers.values() {
+						protocols.push(message_handler.get_protocol_number());
+					}
+
+					let response = msgs::LSPSMessage::Response(jsonrpc::Response::Success(
+						jsonrpc::SuccessResponse {
+							id: request.id,
+							result: protocols.into(),
+							jsonrpc: jsonrpc::VERSION.to_string(),
+						},
+					));
+
+					self.enqueue_message(
+						*sender_node_id,
+						msgs::RawLSPSMessage { payload: serde_json::to_string(&response).unwrap() },
+					);
+					return Ok(());
+				}
+
+				let message_handlers = self.message_handlers.lock().unwrap();
+
+				match message_handlers.get(&request.method.prefix) {
+					Some(message_handler) => {
+						message_handler.handle_lsps_request(request, sender_node_id)
+					}
+					None => {
+						// TODO: really should be something like unsupported request?
+						self.send_invalid_request(sender_node_id);
+						Ok(())
+					}
+				}
+			}
+			msgs::LSPSMessage::Response(response) => {
+				match self.get_pending_request(response.get_id()) {
+					Some(request) => {
+						if request.method.prefix == "lsps0"
+							&& request.method.name == "listprotocols"
+						{
+							match response {
+								jsonrpc::Response::Success(success) => {
+									if let Ok(protocols) =
+										serde_json::from_value::<Vec<u16>>(success.result)
+									{
+										self.enqueue_event(Event::ListProtocols {
+											protocols,
+											counterparty_node_id: *sender_node_id,
+										});
+									}
+								}
+								jsonrpc::Response::Error(error) => {
+									println!("Error: {:?}", error);
+								}
+							}
+							return Ok(());
+						}
+						let message_handlers = self.message_handlers.lock().unwrap();
+
+						match message_handlers.get(&request.method.prefix) {
+							Some(message_handler) => message_handler.handle_lsps_response(
+								request,
+								response,
+								sender_node_id,
+							),
+							None => {
+								log_info!(self.logger, "Receive response for request we no longer have message handler for: {:?}", response);
+								Ok(())
+							}
+						}
+					}
+					None => {
+						log_info!(
+							self.logger,
+							"Received response for unknown request: {:?}",
+							response
+						);
+						Ok(())
+					}
+				}
+			}
+			msgs::LSPSMessage::Notification(notification) => {
+				let message_handlers = self.message_handlers.lock().unwrap();
+
+				match message_handlers.get(&notification.method.prefix) {
+					Some(message_handler) => {
+						message_handler.handle_lsps_notification(notification, sender_node_id)
+					}
+					None => {
+						log_info!(
+							self.logger,
+							"Received notification for unknown protocol: {:?}",
+							notification
+						);
+						Ok(())
+					}
+				}
+			}
+		}
+	}
+
+	fn send_invalid_request(&self, sender_node_id: &PublicKey) {
+		let response =
+			msgs::LSPSMessage::Response(jsonrpc::Response::Error(jsonrpc::ErrorResponse {
+				jsonrpc: jsonrpc::VERSION.to_string(),
+				error: jsonrpc::Error {
+					code: jsonrpc::INVALID_REQUEST_ERROR_CODE,
+					message: "Invalid Request".to_string(),
+					data: None,
+				},
+				id: serde_json::Value::Null,
+			}));
+
+		self.enqueue_message(
+			*sender_node_id,
+			msgs::RawLSPSMessage { payload: serde_json::to_string(&response).unwrap() },
+		);
+	}
+
+	fn enqueue_message(&self, node_id: PublicKey, msg: msgs::RawLSPSMessage) {
+		let mut pending_msgs = self.pending_messages.lock().unwrap();
+		pending_msgs.push((node_id, msg));
+	}
+
+	fn enqueue_event(&self, event: Event) {
+		let mut pending_events = self.pending_events.lock().unwrap();
+		pending_events.push(event);
+	}
+
+	fn insert_pending_request(&self, request: jsonrpc::Request) {
+		let mut pending_requests = self.pending_requests.lock().unwrap();
+		pending_requests.insert(request.id.to_string(), request);
+	}
+
+	fn get_pending_request(&self, request_id: &serde_json::Value) -> Option<jsonrpc::Request> {
+		let mut pending_requests = self.pending_requests.lock().unwrap();
+		pending_requests.remove(&request_id.to_string())
+	}
+}
+
+impl<LMH: Deref, L: Deref, ES: Deref> CustomMessageReader for LSPManager<LMH, L, ES>
+where
+	LMH::Target: LSPMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	type CustomMessage = msgs::RawLSPSMessage;
+
+	fn read<R: io::Read>(
+		&self, message_type: u16, buffer: &mut R,
+	) -> Result<Option<Self::CustomMessage>, lightning::ln::msgs::DecodeError> {
+		match message_type {
+			msgs::LSPS_MESSAGE_TYPE => {
+				let mut payload = String::new();
+				buffer.read_to_string(&mut payload)?;
+				Ok(Some(msgs::RawLSPSMessage { payload }))
+			}
+			_ => Ok(None),
+		}
+	}
+}
+
+impl<LMH: Deref, L: Deref, ES: Deref> CustomMessageHandler for LSPManager<LMH, L, ES>
+where
+	LMH::Target: LSPMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	fn handle_custom_message(
+		&self, msg: Self::CustomMessage, sender_node_id: &PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		match serde_json::from_str(&msg.payload) {
+			Ok(msg) => self.handle_lsps_message(msg, sender_node_id),
+			Err(_) => {
+				self.send_invalid_request(sender_node_id);
+				Ok(())
+			}
+		}
+	}
+
+	fn get_and_clear_pending_msg(&self) -> Vec<(PublicKey, Self::CustomMessage)> {
+		let mut msgs = vec![];
+
+		{
+			let mut pending_messages = self.pending_messages.lock().unwrap();
+			msgs.extend(
+				pending_messages.drain(..).collect::<Vec<(PublicKey, Self::CustomMessage)>>(),
+			);
+		}
+
+		let message_handlers = self.message_handlers.lock().unwrap();
+		for message_handler in message_handlers.values() {
+			let lsps_messages = message_handler.get_and_clear_pending_msg();
+			msgs.extend(lsps_messages);
+		}
+
+		msgs
+	}
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -8,3 +8,7 @@
 // licenses.
 
 //! Types and primitives that implement the LSPS0: Transport Layer specification.
+
+pub mod jsonrpc;
+pub mod message_handler;
+pub mod msgs;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -12,3 +12,4 @@
 pub mod jsonrpc;
 pub mod message_handler;
 pub mod msgs;
+pub mod protocol;

--- a/src/transport/msgs.rs
+++ b/src/transport/msgs.rs
@@ -1,0 +1,67 @@
+use crate::transport::jsonrpc;
+use lightning::impl_writeable_msg;
+use lightning::ln::wire;
+use serde::{Deserialize, Serialize};
+
+pub const LSPS_MESSAGE_TYPE: u16 = 37913;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawLSPSMessage {
+	pub payload: String,
+}
+
+impl_writeable_msg!(RawLSPSMessage, { payload }, {});
+
+impl wire::Type for RawLSPSMessage {
+	fn type_id(&self) -> u16 {
+		LSPS_MESSAGE_TYPE
+	}
+}
+
+/// An [`lsps0_message`] message to be sent to or received from a peer.
+///
+/// [`lsps0_message`]: https://github.com/BitcoinAndLightningLayerSpecs/lsp/blob/49544d1a420cf32ef4726c526a29aa46a09202ff/LSPS0/README.md
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum LSPSMessage {
+	Request(jsonrpc::Request),
+	Response(jsonrpc::Response),
+	Notification(jsonrpc::Notification),
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn deserializes_response() {
+		let json = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "foo": "bar"
+            }
+        }"#;
+		let response: LSPSMessage = serde_json::from_str(json).unwrap();
+		assert_eq!(
+			response,
+			LSPSMessage::Response(jsonrpc::Response::Success(jsonrpc::SuccessResponse {
+				jsonrpc: "2.0".to_string(),
+				id: serde_json::json!(1),
+				result: serde_json::json!({"foo": "bar"}),
+			}))
+		);
+	}
+
+	#[test]
+	fn serializes_response() {
+		let response =
+			LSPSMessage::Response(jsonrpc::Response::Success(jsonrpc::SuccessResponse {
+				jsonrpc: "2.0".to_string(),
+				id: serde_json::json!(1),
+				result: serde_json::json!({"foo": "bar"}),
+			}));
+		let json = serde_json::to_string(&response).unwrap();
+		assert_eq!(json, r#"{"result":{"foo":"bar"},"id":1,"jsonrpc":"2.0"}"#);
+	}
+}

--- a/src/transport/protocol.rs
+++ b/src/transport/protocol.rs
@@ -1,0 +1,301 @@
+use bitcoin::secp256k1::PublicKey;
+use lightning::chain::keysinterface::EntropySource;
+use lightning::log_error;
+use lightning::util::logger::Logger;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::ops::Deref;
+use std::sync::{Arc, Mutex};
+
+use crate::events::Event;
+use crate::transport;
+use crate::transport::jsonrpc;
+use crate::transport::jsonrpc::Prefix;
+use crate::transport::message_handler::ProtocolMessageHandler;
+use crate::transport::msgs::LSPSMessage;
+use crate::utils;
+
+pub enum LSPS0Message {
+	Request(LSPS0Request),
+	Response(LSPS0Response),
+	Notification(LSPS0Notification),
+}
+
+impl From<LSPS0Message> for LSPSMessage {
+	fn from(message: LSPS0Message) -> Self {
+		match message {
+			LSPS0Message::Request(request) => request.into(),
+			LSPS0Message::Response(response) => response.into(),
+			LSPS0Message::Notification(notification) => notification.into(),
+		}
+	}
+}
+
+pub enum LSPS0Request {
+	ListProtocols { request_id: String },
+}
+
+impl TryFrom<jsonrpc::Request> for LSPS0Request {
+	type Error = ();
+
+	fn try_from(request: jsonrpc::Request) -> Result<Self, Self::Error> {
+		match request.method.name.as_str() {
+			"listprotocols" => Ok(Self::ListProtocols { request_id: request.id.to_string() }),
+			_ => Err(()),
+		}
+	}
+}
+
+impl From<LSPS0Request> for LSPSMessage {
+	fn from(request: LSPS0Request) -> Self {
+		match request {
+			LSPS0Request::ListProtocols { request_id } => LSPSMessage::Request(jsonrpc::Request {
+				method: jsonrpc::Method {
+					name: "listprotocols".to_string(),
+					prefix: Prefix::LSPS0,
+				},
+				params: HashMap::new(),
+				id: request_id.into(),
+				jsonrpc: transport::jsonrpc::VERSION.to_string(),
+			}),
+		}
+	}
+}
+
+pub enum LSPS0Response {
+	ListProtocolsSuccess { request_id: String, protocols: Vec<u16> },
+	ListProtocolsError { request_id: String, code: i32, message: String, data: Option<String> },
+}
+
+impl TryFrom<(jsonrpc::Request, jsonrpc::Response)> for LSPS0Response {
+	type Error = ();
+
+	fn try_from(
+		(request, response): (jsonrpc::Request, jsonrpc::Response),
+	) -> Result<Self, Self::Error> {
+		match request.method.name.as_str() {
+			"listprotocols" => match response {
+				jsonrpc::Response::Success(response) => match response.result {
+					serde_json::Value::Array(values) => {
+						let mut protocols = vec![];
+
+						for value in values {
+							if let serde_json::Value::Number(protocol) = value {
+								protocols.push(protocol.as_u64().unwrap() as u16);
+							} else {
+								return Err(());
+							}
+						}
+
+						Ok(Self::ListProtocolsSuccess {
+							request_id: request.id.to_string(),
+							protocols,
+						})
+					}
+					_ => Err(()),
+				},
+				jsonrpc::Response::Error(response) => Ok(Self::ListProtocolsError {
+					request_id: request.id.to_string(),
+					code: response.error.code,
+					message: response.error.message,
+					data: response.error.data.map(|d| d.to_string()),
+				}),
+			},
+			_ => Err(()),
+		}
+	}
+}
+
+impl From<LSPS0Response> for LSPSMessage {
+	fn from(response: LSPS0Response) -> Self {
+		match response {
+			LSPS0Response::ListProtocolsSuccess { request_id, protocols } => {
+				LSPSMessage::Response(jsonrpc::Response::Success(jsonrpc::SuccessResponse {
+					result: serde_json::Value::Array(
+						protocols
+							.into_iter()
+							.map(|p| serde_json::Value::Number(serde_json::Number::from(p as u64)))
+							.collect(),
+					),
+					id: request_id.into(),
+					jsonrpc: transport::jsonrpc::VERSION.to_string(),
+				}))
+			}
+			LSPS0Response::ListProtocolsError { request_id, code, message, data } => {
+				LSPSMessage::Response(jsonrpc::Response::Error(jsonrpc::ErrorResponse {
+					error: jsonrpc::Error {
+						code,
+						message,
+						data: data.map(serde_json::Value::String),
+					},
+					id: request_id.into(),
+					jsonrpc: transport::jsonrpc::VERSION.to_string(),
+				}))
+			}
+		}
+	}
+}
+
+pub enum LSPS0Notification {
+	Unknown,
+}
+
+impl From<jsonrpc::Notification> for LSPS0Notification {
+	fn from(_notification: jsonrpc::Notification) -> Self {
+		Self::Unknown
+	}
+}
+
+impl From<LSPS0Notification> for LSPSMessage {
+	fn from(notification: LSPS0Notification) -> Self {
+		match notification {
+			LSPS0Notification::Unknown => LSPSMessage::Notification(jsonrpc::Notification {
+				method: jsonrpc::Method { name: "unknown".to_string(), prefix: Prefix::LSPS0 },
+				params: HashMap::new(),
+				jsonrpc: transport::jsonrpc::VERSION.to_string(),
+			}),
+		}
+	}
+}
+
+pub struct LSPS0MessageHandler<PMH: Deref, L: Deref, ES: Deref>
+where
+	PMH::Target: ProtocolMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	logger: L,
+	message_handlers: Arc<Mutex<HashMap<Prefix, PMH>>>,
+	pending_messages: Mutex<Vec<(PublicKey, LSPS0Message)>>,
+	entropy_source: ES,
+	pending_events: Mutex<Vec<Event>>,
+}
+
+impl<PMH: Deref, L: Deref, ES: Deref> LSPS0MessageHandler<PMH, L, ES>
+where
+	PMH::Target: ProtocolMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	pub fn new(
+		logger: L, message_handlers: Arc<Mutex<HashMap<Prefix, PMH>>>, entropy_source: ES,
+	) -> Self {
+		Self {
+			logger,
+			message_handlers,
+			pending_messages: Mutex::new(vec![]),
+			entropy_source,
+			pending_events: Mutex::new(vec![]),
+		}
+	}
+
+	pub fn generate_request_id(&self) -> String {
+		let bytes = self.entropy_source.get_secure_random_bytes();
+		utils::hex_str(&bytes[0..16])
+	}
+
+	pub fn list_protocols(
+		&self, counterparty_node_id: PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		self.enqueue_message(
+			counterparty_node_id,
+			LSPS0Message::Request(LSPS0Request::ListProtocols {
+				request_id: self.generate_request_id(),
+			}),
+		);
+		Ok(())
+	}
+
+	fn enqueue_message(&self, counterparty_node_id: PublicKey, message: LSPS0Message) {
+		self.pending_messages.lock().unwrap().push((counterparty_node_id, message));
+	}
+
+	fn enqueue_event(&self, event: Event) {
+		let mut pending_events = self.pending_events.lock().unwrap();
+		pending_events.push(event);
+	}
+}
+
+impl<PMH: Deref, L: Deref, ES: Deref> ProtocolMessageHandler for LSPS0MessageHandler<PMH, L, ES>
+where
+	PMH::Target: ProtocolMessageHandler,
+	L::Target: Logger,
+	ES::Target: EntropySource,
+{
+	type ProtocolRequest = LSPS0Request;
+	type ProtocolResponse = LSPS0Response;
+	type ProtocolNotification = LSPS0Notification;
+	type ProtocolMessage = LSPS0Message;
+
+	fn handle_lsps_request(
+		&self, request: Self::ProtocolRequest, counterparty_node_id: &bitcoin::secp256k1::PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		match request {
+			LSPS0Request::ListProtocols { request_id } => {
+				let message_handlers = self.message_handlers.lock().unwrap();
+				let mut protocols = vec![];
+
+				for message_handler in message_handlers.values() {
+					if let Some(protocol_number) = message_handler.get_protocol_number() {
+						protocols.push(protocol_number);
+					}
+				}
+
+				self.enqueue_message(
+					*counterparty_node_id,
+					LSPS0Message::Response(LSPS0Response::ListProtocolsSuccess {
+						request_id,
+						protocols,
+					}),
+				);
+				Ok(())
+			}
+		}
+	}
+
+	fn handle_lsps_response(
+		&self, response: Self::ProtocolResponse,
+		counterparty_node_id: &bitcoin::secp256k1::PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		match response {
+			LSPS0Response::ListProtocolsSuccess { protocols, .. } => {
+				self.enqueue_event(Event::ListProtocols {
+					counterparty_node_id: *counterparty_node_id,
+					protocols,
+				});
+				Ok(())
+			}
+			LSPS0Response::ListProtocolsError { code, message, data, .. } => {
+				log_error!(
+					self.logger,
+					"Received error({}) response to listprotocols with message: {} data: {:?}",
+					code,
+					message,
+					data
+				);
+				Ok(())
+			}
+		}
+	}
+
+	fn handle_lsps_notification(
+		&self, _notification: Self::ProtocolNotification,
+		_counterparty_node_id: &bitcoin::secp256k1::PublicKey,
+	) -> Result<(), lightning::ln::msgs::LightningError> {
+		Ok(())
+	}
+
+	fn get_and_clear_pending_msg(&self) -> Vec<(bitcoin::secp256k1::PublicKey, LSPS0Message)> {
+		let mut pending_messages = self.pending_messages.lock().unwrap();
+		std::mem::take(&mut *pending_messages)
+	}
+
+	fn get_and_clear_pending_events(&self) -> Vec<Event> {
+		let mut pending_events = self.pending_events.lock().unwrap();
+		std::mem::take(&mut *pending_events)
+	}
+
+	fn get_protocol_number(&self) -> Option<u16> {
+		None
+	}
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+use std::fmt::Write;
+
+#[inline]
+pub fn hex_str(value: &[u8]) -> String {
+	let mut res = String::with_capacity(2 * value.len());
+	for v in value {
+		write!(&mut res, "{:02x}", v).expect("Unable to write");
+	}
+	res
+}


### PR DESCRIPTION
As title says, just a first pass on implementing the LSPS transport layer.  Looking to get feedback on this direction.

I thought we would want to expose the raw jsonrpc::Request/Response/Notification interface to library users because each LSP will likely end up supporting different subset of the full spec and probably custom extensions.  This is why I added the `LSPMessageHandler` trait that lets someone implement handlers for it.  I assume when we implement LSPS request-based protocols we'd provide a handler that handles the logic for that particular protocol.

I'm not so sure on this `LSPManager` object.  My thought was it handled the layer of going from raw string <==> rpc request/response/notification for the user.  It would also expose some api to a higher level and perform whatever bookkeeping is necessary (managing pending request's / ids for them?).

I could use some ideas for how to proceed from here.  I probably should think about how a user of the library will want to use it and work backwards from there.