### PR TITLE
Scaffolding for event handling in future protocols

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,58 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Events are surfaced by the library to indicate some action must be taken
+//! by the end-user.
+//!
+//! Because we don't have a built-in runtime, it's up to the end-user to poll
+//! [`crate::LiquidityManager::get_and_clear_pending_events()`] to receive events.
+
+use std::collections::VecDeque;
+use std::sync::{Condvar, Mutex};
+
+#[derive(Default)]
+pub(crate) struct EventQueue {
+	queue: Mutex<VecDeque<Event>>,
+	condvar: Condvar,
+}
+
+impl EventQueue {
+	pub fn enqueue(&self, event: Event) {
+		{
+			let mut queue = self.queue.lock().unwrap();
+			queue.push_back(event);
+		}
+
+		self.condvar.notify_one();
+	}
+
+	pub fn wait_next_event(&self) -> Event {
+		let mut queue =
+			self.condvar.wait_while(self.queue.lock().unwrap(), |queue| queue.is_empty()).unwrap();
+
+		let event = queue.pop_front().expect("non empty queue");
+		let should_notify = !queue.is_empty();
+
+		drop(queue);
+
+		if should_notify {
+			self.condvar.notify_one();
+		}
+
+		event
+	}
+
+	pub fn get_and_clear_pending_events(&self) -> Vec<Event> {
+		self.queue.lock().unwrap().drain(..).collect()
+	}
+}
+
+/// Event which you should probably take some action in response to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod channel_request;
+pub mod events;
 mod jit_channel;
 mod transport;
 mod utils;


### PR DESCRIPTION
Adds the concept of events to the library.  Future protocols should:

- add Event enum variants
- give protocol message handler a reference to the `pending_events` EventQueue.
- push any relevant events as they are generated inside their protocol

End user is currently expected to poll for events using either:

- `get_and_clear_pending_events` in order to retrieve all currently queued events without blocking (returns empty vec if nothing present)

or

- `get_next_event` blocks until next event is ready and returns it


Perhaps we want an async version that returns a Future as well?