### PR TITLE
take and hold a reference to ChannelManager

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -36,7 +36,7 @@ impl EventQueue {
 		let mut queue =
 			self.condvar.wait_while(self.queue.lock().unwrap(), |queue| queue.is_empty()).unwrap();
 
-		let event = queue.pop_front().expect("non empty queue");
+		let event = queue.pop_front().expect("non-empty queue");
 		let should_notify = !queue.is_empty();
 
 		drop(queue);


### PR DESCRIPTION
There's no real need for the LiquidityManager to actually hold the channel manager.  Once LSPS1 and/or LSPS2 are landed we should remove the reference from LiquidityManager as the reference will just pass through to the constructors of the protocols.

Instead of putting the type constraints on just the `new` method, this way is closer to what it will actually look like once the `LiquidityManager` will hold LSPS1/2 objects that have these same generics.