### PR TITLE
Pin `serde_json` in CI to maintain MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,9 @@ jobs:
         run: cargo update -p tokio --precise "1.14.1" --verbose
       - name: Pin serde for MSRV
         if: matrix.msrv
-        run: cargo update -p serde --precise "1.0.156" --verbose
+        run: |
+          cargo update -p serde_json --precise "1.0.99" --verbose
+          cargo update -p serde --precise "1.0.156" --verbose
       - name: Pin log for MSRV
         if: matrix.msrv
         run: cargo update -p log --precise "0.4.18" --verbose


### PR DESCRIPTION
The `serde_json` crate switched to Rust edition 2021 starting with v1.0.101, i.e., has MSRV of 1.56. It also requires `serde` v1.0.166 starting with v1.0.100.

We therefore pin it to v1.0.99 in CI to fix our MSRV checks.