### PR TITLE
Add `Confirm`/`Listen`/`Filter` boilerplate

### DIFF
--- a/src/transport/message_handler.rs
+++ b/src/transport/message_handler.rs
@@ -2,10 +2,9 @@ use crate::events::{Event, EventQueue};
 use crate::transport::msgs::{LSPSMessage, RawLSPSMessage, LSPS_MESSAGE_TYPE};
 use crate::transport::protocol::LSPS0MessageHandler;
 
-use bitcoin::secp256k1::PublicKey;
-use lightning::chain;
 use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
-use lightning::ln::channelmanager::ChannelManager;
+use lightning::chain::{self, BestBlock, Confirm, Filter, Listen};
+use lightning::ln::channelmanager::{ChainParameters, ChannelManager};
 use lightning::ln::features::{InitFeatures, NodeFeatures};
 use lightning::ln::msgs::{ErrorAction, LightningError};
 use lightning::ln::peer_handler::CustomMessageHandler;
@@ -14,11 +13,16 @@ use lightning::routing::router::Router;
 use lightning::sign::{EntropySource, NodeSigner, SignerProvider};
 use lightning::util::logger::{Level, Logger};
 use lightning::util::ser::Readable;
+
+use bitcoin::blockdata::constants::genesis_block;
+use bitcoin::secp256k1::PublicKey;
+use bitcoin::BlockHash;
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io;
 use std::ops::Deref;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 
 const LSPS_FEATURE_BIT: usize = 729;
 
@@ -54,6 +58,7 @@ pub struct LiquidityManager<
 	SP: Deref,
 	L: Deref,
 	NS: Deref,
+	C: Deref,
 > where
 	ES::Target: EntropySource,
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
@@ -63,6 +68,7 @@ pub struct LiquidityManager<
 	SP::Target: SignerProvider,
 	L::Target: Logger,
 	NS::Target: NodeSigner,
+	C::Target: Filter,
 {
 	pending_messages: Arc<Mutex<Vec<(PublicKey, LSPSMessage)>>>,
 	pending_events: Arc<EventQueue>,
@@ -70,10 +76,22 @@ pub struct LiquidityManager<
 	lsps0_message_handler: LSPS0MessageHandler<ES>,
 	provider_config: Option<LiquidityProviderConfig>,
 	channel_manager: Arc<ChannelManager<M, T, ES, NS, SP, F, R, L>>,
+	chain_source: Option<C>,
+	genesis_hash: BlockHash,
+	best_block: RwLock<BestBlock>,
 }
 
-impl<ES: Deref, M: Deref, T: Deref, F: Deref, R: Deref, SP: Deref, L: Deref, NS: Deref>
-	LiquidityManager<ES, M, T, F, R, SP, L, NS>
+impl<
+		ES: Deref,
+		M: Deref,
+		T: Deref,
+		F: Deref,
+		R: Deref,
+		SP: Deref,
+		L: Deref,
+		NS: Deref,
+		C: Deref,
+	> LiquidityManager<ES, M, T, F, R, SP, L, NS, C>
 where
 	ES::Target: EntropySource,
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
@@ -83,13 +101,15 @@ where
 	SP::Target: SignerProvider,
 	L::Target: Logger,
 	NS::Target: NodeSigner,
+	C::Target: Filter,
 {
 	/// Constructor for the LiquidityManager
 	///
 	/// Sets up the required protocol message handlers based on the given [`LiquidityProviderConfig`].
 	pub fn new(
 		entropy_source: ES, provider_config: Option<LiquidityProviderConfig>,
-		channel_manager: Arc<ChannelManager<M, T, ES, NS, SP, F, R, L>>,
+		channel_manager: Arc<ChannelManager<M, T, ES, NS, SP, F, R, L>>, chain_source: Option<C>,
+		chain_params: ChainParameters,
 	) -> Self
 where {
 		let pending_messages = Arc::new(Mutex::new(vec![]));
@@ -104,6 +124,9 @@ where {
 			lsps0_message_handler,
 			provider_config,
 			channel_manager,
+			chain_source,
+			genesis_hash: genesis_block(chain_params.network).header.block_hash(),
+			best_block: RwLock::new(chain_params.best_block),
 		}
 	}
 
@@ -141,8 +164,17 @@ where {
 	}
 }
 
-impl<ES: Deref, M: Deref, T: Deref, F: Deref, R: Deref, SP: Deref, L: Deref, NS: Deref>
-	CustomMessageReader for LiquidityManager<ES, M, T, F, R, SP, L, NS>
+impl<
+		ES: Deref,
+		M: Deref,
+		T: Deref,
+		F: Deref,
+		R: Deref,
+		SP: Deref,
+		L: Deref,
+		NS: Deref,
+		C: Deref,
+	> CustomMessageReader for LiquidityManager<ES, M, T, F, R, SP, L, NS, C>
 where
 	ES::Target: EntropySource,
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
@@ -152,6 +184,7 @@ where
 	SP::Target: SignerProvider,
 	L::Target: Logger,
 	NS::Target: NodeSigner,
+	C::Target: Filter,
 {
 	type CustomMessage = RawLSPSMessage;
 
@@ -165,8 +198,17 @@ where
 	}
 }
 
-impl<ES: Deref, M: Deref, T: Deref, F: Deref, R: Deref, SP: Deref, L: Deref, NS: Deref>
-	CustomMessageHandler for LiquidityManager<ES, M, T, F, R, SP, L, NS>
+impl<
+		ES: Deref,
+		M: Deref,
+		T: Deref,
+		F: Deref,
+		R: Deref,
+		SP: Deref,
+		L: Deref,
+		NS: Deref,
+		C: Deref,
+	> CustomMessageHandler for LiquidityManager<ES, M, T, F, R, SP, L, NS, C>
 where
 	ES::Target: EntropySource,
 	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
@@ -176,6 +218,7 @@ where
 	SP::Target: SignerProvider,
 	L::Target: Logger,
 	NS::Target: NodeSigner,
+	C::Target: Filter,
 {
 	fn handle_custom_message(
 		&self, msg: Self::CustomMessage, sender_node_id: &PublicKey,
@@ -227,5 +270,105 @@ where
 		}
 
 		features
+	}
+}
+
+impl<
+		ES: Deref,
+		M: Deref,
+		T: Deref,
+		F: Deref,
+		R: Deref,
+		SP: Deref,
+		L: Deref,
+		NS: Deref,
+		C: Deref,
+	> Listen for LiquidityManager<ES, M, T, F, R, SP, L, NS, C>
+where
+	ES::Target: EntropySource,
+	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
+	T::Target: BroadcasterInterface,
+	F::Target: FeeEstimator,
+	R::Target: Router,
+	SP::Target: SignerProvider,
+	L::Target: Logger,
+	NS::Target: NodeSigner,
+	C::Target: Filter,
+{
+	fn filtered_block_connected(
+		&self, header: &bitcoin::BlockHeader, txdata: &chain::transaction::TransactionData,
+		height: u32,
+	) {
+		{
+			let best_block = self.best_block.read().unwrap();
+			assert_eq!(best_block.block_hash(), header.prev_blockhash,
+			"Blocks must be connected in chain-order - the connected header must build on the last connected header");
+			assert_eq!(best_block.height(), height - 1,
+			"Blocks must be connected in chain-order - the connected block height must be one greater than the previous height");
+		}
+
+		self.transactions_confirmed(header, txdata, height);
+		self.best_block_updated(header, height);
+	}
+
+	fn block_disconnected(&self, header: &bitcoin::BlockHeader, height: u32) {
+		let new_height = height - 1;
+		{
+			let mut best_block = self.best_block.write().unwrap();
+			assert_eq!(best_block.block_hash(), header.block_hash(),
+				"Blocks must be disconnected in chain-order - the disconnected header must be the last connected header");
+			assert_eq!(best_block.height(), height,
+				"Blocks must be disconnected in chain-order - the disconnected block must have the correct height");
+			*best_block = BestBlock::new(header.prev_blockhash, new_height)
+		}
+
+		// TODO: Call block_disconnected on all sub-modules that require it, e.g., CRManager.
+		// Internally this should call transaction_unconfirmed for all transactions that were
+		// confirmed at a height <= the one we now disconnected.
+	}
+}
+
+impl<
+		ES: Deref,
+		M: Deref,
+		T: Deref,
+		F: Deref,
+		R: Deref,
+		SP: Deref,
+		L: Deref,
+		NS: Deref,
+		C: Deref,
+	> Confirm for LiquidityManager<ES, M, T, F, R, SP, L, NS, C>
+where
+	ES::Target: EntropySource,
+	M::Target: chain::Watch<<SP::Target as SignerProvider>::Signer>,
+	T::Target: BroadcasterInterface,
+	F::Target: FeeEstimator,
+	R::Target: Router,
+	SP::Target: SignerProvider,
+	L::Target: Logger,
+	NS::Target: NodeSigner,
+	C::Target: Filter,
+{
+	fn transactions_confirmed(
+		&self, header: &bitcoin::BlockHeader, txdata: &chain::transaction::TransactionData,
+		height: u32,
+	) {
+		// TODO: Call transactions_confirmed on all sub-modules that require it, e.g., CRManager.
+	}
+
+	fn transaction_unconfirmed(&self, txid: &bitcoin::Txid) {
+		// TODO: Call transaction_unconfirmed on all sub-modules that require it, e.g., CRManager.
+		// Internally this should call transaction_unconfirmed for all transactions that were
+		// confirmed at a height <= the one we now unconfirmed.
+	}
+
+	fn best_block_updated(&self, header: &bitcoin::BlockHeader, height: u32) {
+		// TODO: Call best_block_updated on all sub-modules that require it, e.g., CRManager.
+	}
+
+	fn get_relevant_txids(&self) -> Vec<(bitcoin::Txid, Option<bitcoin::BlockHash>)> {
+		// TODO: Collect relevant txids from all sub-modules that, e.g., CRManager.
+		Vec::new()
 	}
 }


### PR DESCRIPTION
As the LSPS implementations might need to have access to chain confirmation data (e.g., LSPS1/ChannelRequest would need to know when an on-chain transaction paying for a channel)

To this end, we add the necessary boilerplate to `LiquidityManager` for it to implement `Confirm`/`Listen`, take a `Filter` chain source, and then delegate the calls internally to the respective implementations.

Unfortunately the interfaces do not allow to watch for an arbitrary address getting paid, so we'll need to delegate this part via events to the on-chain wallet implemetation. After telling us about the txid of an inbound payment, we can then use `Filter`/`Confirm`/`Listen` to assert it is confirmed and isn't unconfirmed before we open a channel.