### PR TITLE
Expose `lsps0_message_handler.handle_request`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ mod transport;
 mod utils;
 
 pub use transport::message_handler::{LiquidityManager, LiquidityProviderConfig};
+pub use transport::msgs;

--- a/src/transport/message_handler.rs
+++ b/src/transport/message_handler.rs
@@ -67,7 +67,8 @@ pub struct LiquidityManager<
 	pending_messages: Arc<Mutex<Vec<(PublicKey, LSPSMessage)>>>,
 	pending_events: Arc<EventQueue>,
 	request_id_to_method_map: Mutex<HashMap<String, String>>,
-	lsps0_message_handler: LSPS0MessageHandler<ES>,
+	/// lsps0 message handler
+	pub lsps0_message_handler: LSPS0MessageHandler<ES>,
 	provider_config: Option<LiquidityProviderConfig>,
 	channel_manager: Arc<ChannelManager<M, T, ES, NS, SP, F, R, L>>,
 }

--- a/src/transport/msgs.rs
+++ b/src/transport/msgs.rs
@@ -1,3 +1,4 @@
+#![allow(missing_docs)]
 use lightning::impl_writeable_msg;
 use lightning::ln::wire;
 use serde::de;


### PR DESCRIPTION
Would `lsps0_message_handler.handle_request` be public and return the response?
Such that people integrate the handler will easier to verify the handler work after integration.
Thanks in advance. :pray: 