### PR TITLE
LSPS0: List Protocols

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -13,6 +13,7 @@
 //! Because we don't have a built-in runtime, it's up to the end-user to poll
 //! [`crate::LiquidityManager::get_and_clear_pending_events()`] to receive events.
 
+use crate::transport::msgs::{LSPS0Response, RequestId};
 use std::collections::VecDeque;
 use std::sync::{Condvar, Mutex};
 
@@ -55,4 +56,16 @@ impl EventQueue {
 
 /// Event which you should probably take some action in response to.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Event {}
+pub struct Event {
+	/// The id from the request
+	pub id: RequestId,
+	/// The result of request
+	pub result: EventResult,
+}
+
+/// Content of the event
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventResult {
+	/// The LSPS0 response
+	LSPS0(LSPS0Response),
+}


### PR DESCRIPTION
We need to expose the `lsps0.listprotocols` method and let it become queriable from others.

In #15, the return of `LSPS0Response` of `handle_request` is rejected.  And there is no return after handling the lsps0 request.

If I am not misunderstanding, the `LSPS0Response` should pop up as an Event, and anyone sending the query can acquire the event after the query, and by comparing the `RequestId` to get the corresponding event for the request.

This PR handles the lsps0 request and creates an event when handling the request, such that we can do an lsps0 query and get the result.

If there is anything I can do to make this RP be merged easier, please let me know.  
Thanks. :pray: 