### PR TITLE
pin memchr to 2.5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
           cargo update -p proc-macro2 --precise "1.0.65" --verbose
           # Sadly the log crate is always a dependency of tokio until 1.20, and has no reasonable MSRV guarantees
           cargo update -p log --precise "0.4.18" --verbose
+          # The memchr crate switched to Rust edition 2021 starting with v2.6.0
+          cargo update -p memchr --precise "2.5.0" --verbose
       - name: Cargo check
         run: cargo check --release
       - name: Check documentation


### PR DESCRIPTION
In 2.6.0 they switched to Rust edition 2021 and break our MSRV guarantees.