### PR TITLE
Add MPP support to LSPS2

### DIFF
--- a/src/jit_channel/channel_manager.rs
+++ b/src/jit_channel/channel_manager.rs
@@ -713,8 +713,10 @@ where
 					if let Some(jit_channel) = peer_state.outbound_channels_by_scid.get_mut(&scid) {
 						match jit_channel.channel_ready() {
 							Ok((htlcs, total_amt_to_forward_msat)) => {
-								let amounts_to_forward_msat =
-								calculate_amount_to_forward_per_htlc(&htlcs, total_amt_to_forward_msat);
+								let amounts_to_forward_msat = calculate_amount_to_forward_per_htlc(
+									&htlcs,
+									total_amt_to_forward_msat,
+								);
 
 								for (intercept_id, amount_to_forward_msat) in
 									amounts_to_forward_msat
@@ -1294,7 +1296,8 @@ fn calculate_amount_to_forward_per_htlc(
 	let mut per_htlc_forwards = vec![];
 
 	for (index, htlc) in htlcs.iter().enumerate() {
-		let proportional_fee_amt_msat = total_fee_msat * htlc.expected_outbound_amount_msat / total_received_msat;		
+		let proportional_fee_amt_msat =
+			total_fee_msat * htlc.expected_outbound_amount_msat / total_received_msat;
 
 		let mut actual_fee_amt_msat = std::cmp::min(fee_remaining_msat, proportional_fee_amt_msat);
 		fee_remaining_msat -= actual_fee_amt_msat;
@@ -1306,7 +1309,7 @@ fn calculate_amount_to_forward_per_htlc(
 		let amount_to_forward_msat = htlc.expected_outbound_amount_msat - actual_fee_amt_msat;
 
 		per_htlc_forwards.push((htlc.intercept_id, amount_to_forward_msat))
-	}	
+	}
 
 	per_htlc_forwards
 }

--- a/src/jit_channel/channel_manager.rs
+++ b/src/jit_channel/channel_manager.rs
@@ -45,6 +45,12 @@ use crate::jit_channel::msgs::{
 
 const SUPPORTED_SPEC_VERSIONS: [u16; 1] = [1];
 
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+struct InterceptedHTLC {
+	intercept_id: InterceptId,
+	expected_outbound_amount_msat: u64,
+}
+
 struct ChannelStateError(String);
 
 impl From<ChannelStateError> for LightningError {
@@ -192,13 +198,19 @@ enum OutboundJITChannelState {
 		payment_size_msat: Option<u64>,
 		opening_fee_params: OpeningFeeParams,
 	},
+	PendingPaymentReceived {
+		htlcs: Vec<InterceptedHTLC>,
+		payment_size_msat: u64,
+		amt_to_forward_msat: u64,
+		opening_fee_msat: u64,
+	},
 	PendingChannelOpen {
-		intercept_id: InterceptId,
+		htlcs: Vec<InterceptedHTLC>,
 		opening_fee_msat: u64,
 		amt_to_forward_msat: u64,
 	},
 	ChannelReady {
-		intercept_id: InterceptId,
+		htlcs: Vec<InterceptedHTLC>,
 		amt_to_forward_msat: u64,
 	},
 }
@@ -216,20 +228,68 @@ impl OutboundJITChannelState {
 		}
 	}
 
-	pub fn htlc_intercepted(
-		&self, expected_outbound_amount_msat: u64, intercept_id: InterceptId,
-	) -> Result<Self, ChannelStateError> {
+	pub fn htlc_intercepted(&self, htlc: InterceptedHTLC) -> Result<Self, ChannelStateError> {
 		match self {
-			OutboundJITChannelState::InvoiceParametersGenerated { opening_fee_params, .. } => {
-				compute_opening_fee(
-					expected_outbound_amount_msat,
-					opening_fee_params.min_fee_msat,
-					opening_fee_params.proportional.into(),
-				).map(|opening_fee_msat| OutboundJITChannelState::PendingChannelOpen {
-					intercept_id,
-					opening_fee_msat,
-					amt_to_forward_msat: expected_outbound_amount_msat - opening_fee_msat,
-				}).ok_or(ChannelStateError(format!("Could not compute valid opening fee with min_fee_msat = {}, proportional = {}, and expected_outbound_amount_msat = {}", opening_fee_params.min_fee_msat, opening_fee_params.proportional, expected_outbound_amount_msat)))
+			OutboundJITChannelState::InvoiceParametersGenerated {
+				opening_fee_params,
+				payment_size_msat,
+				..
+			} => {
+				let htlcs = vec![htlc];
+				let supports_mpp = payment_size_msat.is_some();
+				let payment_size_msat =
+					payment_size_msat.unwrap_or(htlc.expected_outbound_amount_msat);
+				let opening_fee_msat = compute_opening_fee(payment_size_msat, opening_fee_params.min_fee_msat, opening_fee_params.proportional.into()).ok_or(ChannelStateError(format!("Could not compute valid opening fee with min_fee_msat = {}, proportional = {}, and expected_outbound_amount_msat = {}", opening_fee_params.min_fee_msat, opening_fee_params.proportional, htlc.expected_outbound_amount_msat)))?;
+				let amt_to_forward_msat = payment_size_msat - opening_fee_msat;
+
+				if htlc.expected_outbound_amount_msat >= payment_size_msat
+					&& amt_to_forward_msat > 0
+				{
+					Ok(OutboundJITChannelState::PendingChannelOpen {
+						htlcs,
+						opening_fee_msat,
+						amt_to_forward_msat,
+					})
+				} else {
+					if supports_mpp {
+						Ok(OutboundJITChannelState::PendingPaymentReceived {
+							htlcs,
+							amt_to_forward_msat,
+							opening_fee_msat,
+							payment_size_msat,
+						})
+					} else {
+						Err(ChannelStateError("HTLC is too small to pay opening fee".to_string()))
+					}
+				}
+			}
+			OutboundJITChannelState::PendingPaymentReceived {
+				htlcs,
+				payment_size_msat,
+				amt_to_forward_msat,
+				opening_fee_msat,
+			} => {
+				let mut htlcs = htlcs.clone();
+				htlcs.push(htlc);
+
+				let total_expected_outbound_amount_msat = htlcs
+					.iter()
+					.fold(0, |total_msat, htlc| total_msat + htlc.expected_outbound_amount_msat);
+
+				if total_expected_outbound_amount_msat >= *payment_size_msat {
+					return Ok(OutboundJITChannelState::PendingPaymentReceived {
+						htlcs,
+						payment_size_msat: *payment_size_msat,
+						amt_to_forward_msat: *amt_to_forward_msat,
+						opening_fee_msat: *opening_fee_msat,
+					});
+				}
+
+				Ok(OutboundJITChannelState::PendingChannelOpen {
+					htlcs,
+					opening_fee_msat: *opening_fee_msat,
+					amt_to_forward_msat: *amt_to_forward_msat,
+				})
 			}
 			state => Err(ChannelStateError(format!(
 				"Invoice params received when JIT Channel was in state: {:?}",
@@ -240,14 +300,12 @@ impl OutboundJITChannelState {
 
 	pub fn channel_ready(&self) -> Result<Self, ChannelStateError> {
 		match self {
-			OutboundJITChannelState::PendingChannelOpen {
-				intercept_id,
-				amt_to_forward_msat,
-				..
-			} => Ok(OutboundJITChannelState::ChannelReady {
-				intercept_id: *intercept_id,
-				amt_to_forward_msat: *amt_to_forward_msat,
-			}),
+			OutboundJITChannelState::PendingChannelOpen { htlcs, amt_to_forward_msat, .. } => {
+				Ok(OutboundJITChannelState::ChannelReady {
+					htlcs: htlcs.clone(),
+					amt_to_forward_msat: *amt_to_forward_msat,
+				})
+			}
 			state => Err(ChannelStateError(format!(
 				"Channel ready received when JIT Channel was in state: {:?}",
 				state
@@ -276,16 +334,17 @@ impl OutboundJITChannel {
 	}
 
 	pub fn htlc_intercepted(
-		&mut self, expected_outbound_amount_msat: u64, intercept_id: InterceptId,
-	) -> Result<(u64, u64), LightningError> {
-		self.state = self.state.htlc_intercepted(expected_outbound_amount_msat, intercept_id)?;
+		&mut self, htlc: InterceptedHTLC,
+	) -> Result<Option<(u64, u64)>, LightningError> {
+		self.state = self.state.htlc_intercepted(htlc)?;
 
 		match &self.state {
+			OutboundJITChannelState::PendingPaymentReceived { .. } => Ok(None),
 			OutboundJITChannelState::PendingChannelOpen {
 				opening_fee_msat,
 				amt_to_forward_msat,
 				..
-			} => Ok((*opening_fee_msat, *amt_to_forward_msat)),
+			} => Ok(Some((*opening_fee_msat, *amt_to_forward_msat))),
 			impossible_state => Err(LightningError {
 				err: format!(
 					"Impossible state transition during htlc_intercepted to {:?}",
@@ -296,12 +355,12 @@ impl OutboundJITChannel {
 		}
 	}
 
-	pub fn channel_ready(&mut self) -> Result<(InterceptId, u64), LightningError> {
+	pub fn channel_ready(&mut self) -> Result<(Vec<InterceptedHTLC>, u64), LightningError> {
 		self.state = self.state.channel_ready()?;
 
 		match &self.state {
-			OutboundJITChannelState::ChannelReady { intercept_id, amt_to_forward_msat } => {
-				Ok((*intercept_id, *amt_to_forward_msat))
+			OutboundJITChannelState::ChannelReady { htlcs, amt_to_forward_msat } => {
+				Ok((htlcs.clone(), *amt_to_forward_msat))
 			}
 			impossible_state => Err(LightningError {
 				err: format!(
@@ -615,8 +674,7 @@ where
 	}
 
 	pub(crate) fn htlc_intercepted(
-		&self, scid: u64, intercept_id: InterceptId, inbound_amount_msat: u64,
-		expected_outbound_amount_msat: u64,
+		&self, scid: u64, intercept_id: InterceptId, expected_outbound_amount_msat: u64,
 	) -> Result<(), APIError> {
 		let peer_by_scid = self.peer_by_scid.read().unwrap();
 		if let Some(counterparty_node_id) = peer_by_scid.get(&scid) {
@@ -625,25 +683,17 @@ where
 				Some(inner_state_lock) => {
 					let mut peer_state = inner_state_lock.lock().unwrap();
 					if let Some(jit_channel) = peer_state.outbound_channels_by_scid.get_mut(&scid) {
-						// TODO: Need to support MPP payments. If payment_amount_msat is known, needs to queue intercepted HTLCs in a map by payment_hash
-						//       LiquidityManager will need to be regularly polled so it can continually check if the payment amount has been received
-						//       and can release the payment or if the channel valid_until has expired and should be failed.
-						//       Can perform check each time HTLC is received and on interval? I guess interval only needs to check expiration as
-						//       we can only reach threshold when htlc is intercepted.
-
-						match jit_channel
-							.htlc_intercepted(expected_outbound_amount_msat, intercept_id)
-						{
-							Ok((opening_fee_msat, amt_to_forward_msat)) => {
+						let htlc = InterceptedHTLC { intercept_id, expected_outbound_amount_msat };
+						match jit_channel.htlc_intercepted(htlc) {
+							Ok(Some((opening_fee_msat, amt_to_forward_msat))) => {
 								self.enqueue_event(Event::LSPS2(LSPS2Event::OpenChannel {
 									their_network_key: counterparty_node_id.clone(),
-									inbound_amount_msat,
-									expected_outbound_amount_msat,
 									amt_to_forward_msat,
 									opening_fee_msat,
 									user_channel_id: scid as u128,
 								}));
 							}
+							Ok(None) => {}
 							Err(e) => {
 								self.channel_manager.fail_intercepted_htlc(intercept_id)?;
 								peer_state.outbound_channels_by_scid.remove(&scid);
@@ -675,13 +725,39 @@ where
 					let mut peer_state = inner_state_lock.lock().unwrap();
 					if let Some(jit_channel) = peer_state.outbound_channels_by_scid.get_mut(&scid) {
 						match jit_channel.channel_ready() {
-							Ok((intercept_id, amt_to_forward_msat)) => {
-								self.channel_manager.forward_intercepted_htlc(
-									intercept_id,
-									channel_id,
-									*counterparty_node_id,
-									amt_to_forward_msat,
-								)?;
+							Ok((htlcs, amt_to_forward_msat)) => {
+								// TODO: review strategy for handling batch forwarding of these htlcs
+								let min_htlc_msat = self
+									.channel_manager
+									.list_channels_with_counterparty(counterparty_node_id)
+									.iter()
+									.find(|channel| channel.channel_id == *channel_id)
+									.map(|details| details.next_outbound_htlc_minimum_msat)
+									.ok_or(APIError::APIMisuseError {
+										err: format!("Channel with id {} not found", channel_id),
+									})?;
+
+								let total_msat = htlcs
+									.iter()
+									.fold(0, |acc, htlc| acc + htlc.expected_outbound_amount_msat);
+								let mut fee_msat = total_msat - amt_to_forward_msat;
+
+								for htlc in htlcs {
+									let max_we_can_take =
+										htlc.expected_outbound_amount_msat - min_htlc_msat;
+									let amount_of_fee_to_take =
+										std::cmp::min(fee_msat, max_we_can_take);
+									let amount_to_forward_msat =
+										htlc.expected_outbound_amount_msat - amount_of_fee_to_take;
+									self.channel_manager.forward_intercepted_htlc(
+										htlc.intercept_id,
+										channel_id,
+										*counterparty_node_id,
+										amount_to_forward_msat,
+									)?;
+
+									fee_msat -= amount_of_fee_to_take;
+								}
 							}
 							Err(e) => {
 								return Err(APIError::APIMisuseError {

--- a/src/jit_channel/channel_manager.rs
+++ b/src/jit_channel/channel_manager.rs
@@ -13,6 +13,7 @@ use std::ops::Deref;
 use std::sync::{Arc, Mutex, RwLock};
 
 use bitcoin::secp256k1::PublicKey;
+use lightning::chain;
 use lightning::chain::chaininterface::{BroadcasterInterface, FeeEstimator};
 use lightning::ln::channelmanager::{ChannelManager, InterceptId};
 use lightning::ln::msgs::{
@@ -24,7 +25,6 @@ use lightning::routing::router::Router;
 use lightning::sign::{EntropySource, NodeSigner, SignerProvider};
 use lightning::util::errors::APIError;
 use lightning::util::logger::{Level, Logger};
-use lightning::{chain, log_debug};
 
 use crate::events::EventQueue;
 use crate::jit_channel::utils::{compute_opening_fee, is_valid_opening_fee_params};
@@ -233,8 +233,6 @@ impl OutboundJITChannelState {
 				let total_expected_outbound_amount_msat =
 					htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum();
 
-				let supports_mpp = payment_size_msat.is_some();
-
 				let expected_payment_size_msat =
 					payment_size_msat.unwrap_or(total_expected_outbound_amount_msat);
 
@@ -250,7 +248,8 @@ impl OutboundJITChannelState {
 					)
 				))?;
 
-				let amt_to_forward_msat = expected_payment_size_msat - opening_fee_msat;
+				let amt_to_forward_msat =
+					expected_payment_size_msat.saturating_sub(opening_fee_msat);
 
 				if total_expected_outbound_amount_msat >= expected_payment_size_msat
 					&& amt_to_forward_msat > 0
@@ -261,7 +260,8 @@ impl OutboundJITChannelState {
 						amt_to_forward_msat,
 					})
 				} else {
-					if supports_mpp {
+					// payment size being specified means MPP is supported
+					if payment_size_msat.is_some() {
 						Ok(OutboundJITChannelState::AwaitingPayment {
 							min_fee_msat: *min_fee_msat,
 							proportional_fee: *proportional_fee,
@@ -323,7 +323,7 @@ impl OutboundJITChannel {
 
 		match &self.state {
 			OutboundJITChannelState::AwaitingPayment { htlcs, payment_size_msat, .. } => {
-				// log that we received an htlc but are still awaiting payment
+				// TODO: log that we received an htlc but are still awaiting payment
 				Ok(None)
 			}
 			OutboundJITChannelState::PendingChannelOpen {
@@ -713,9 +713,12 @@ where
 					if let Some(jit_channel) = peer_state.outbound_channels_by_scid.get_mut(&scid) {
 						match jit_channel.channel_ready() {
 							Ok((htlcs, total_amt_to_forward_msat)) => {
-								let amounts_to_forward_msat = calculate_amount_to_forward(&htlcs, total_amt_to_forward_msat);
+								let amounts_to_forward_msat =
+								calculate_amount_to_forward_per_htlc(&htlcs, total_amt_to_forward_msat);
 
-								for (intercept_id, amount_to_forward_msat) in amounts_to_forward_msat {
+								for (intercept_id, amount_to_forward_msat) in
+									amounts_to_forward_msat
+								{
 									self.channel_manager.forward_intercepted_htlc(
 										intercept_id,
 										channel_id,
@@ -1279,36 +1282,30 @@ where
 	}
 }
 
-fn calculate_amount_to_forward(htlcs: &[InterceptedHTLC], total_amt_to_forward_msat: u64) -> Vec<(InterceptId, u64)> {
-	let total_received_msat: u64 = htlcs
+fn calculate_amount_to_forward_per_htlc(
+	htlcs: &[InterceptedHTLC], total_amt_to_forward_msat: u64,
+) -> Vec<(InterceptId, u64)> {
+	let total_received_msat: u64 =
+		htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum();
+
+	let mut fee_remaining_msat = total_received_msat - total_amt_to_forward_msat;
+
+	let fee_percentage = fee_remaining_msat as f64 / total_received_msat as f64;
+
+	htlcs
 		.iter()
-		.map(|htlc| htlc.expected_outbound_amount_msat)
-		.sum();
+		.map(|htlc| {
+			let proportional_fee_amt_msat =
+				(htlc.expected_outbound_amount_msat as f64 * fee_percentage).ceil() as u64;
+			let actual_fee_amt_msat = std::cmp::min(fee_remaining_msat, proportional_fee_amt_msat);
 
-	let mut fee_remaining_msat =
-		total_received_msat - total_amt_to_forward_msat;
+			let amount_to_forward_msat = htlc.expected_outbound_amount_msat - actual_fee_amt_msat;
 
-	let fee_percentage =
-		fee_remaining_msat as f64 / total_received_msat as f64;
+			fee_remaining_msat -= actual_fee_amt_msat;
 
-	htlcs.iter().map(|htlc| {
-		let proportional_fee_amt_msat = (htlc
-			.expected_outbound_amount_msat
-			as f64 * fee_percentage)
-			.ceil() as u64;
-		let actual_fee_amt_msat = std::cmp::min(
-			fee_remaining_msat,
-			proportional_fee_amt_msat,
-		);
-
-		let amount_to_forward_msat =
-			htlc.expected_outbound_amount_msat - actual_fee_amt_msat;
-		
-
-		fee_remaining_msat -= actual_fee_amt_msat;
-		
-		(htlc.intercept_id, amount_to_forward_msat)
-	}).collect()
+			(htlc.intercept_id, amount_to_forward_msat)
+		})
+		.collect()
 }
 
 #[cfg(test)]
@@ -1318,6 +1315,7 @@ mod tests {
 
 	#[test]
 	fn test_calculate_amount_to_forward() {
+		// TODO: Use proptest to generate random allocations
 		let htlcs = vec![
 			InterceptedHTLC {
 				intercept_id: InterceptId([0; 32]),
@@ -1335,7 +1333,7 @@ mod tests {
 
 		let total_amt_to_forward_msat = 5000;
 
-		let result = calculate_amount_to_forward(&htlcs, total_amt_to_forward_msat);
+		let result = calculate_amount_to_forward_per_htlc(&htlcs, total_amt_to_forward_msat);
 
 		// 1000 in fees total, (1000 / 6000) 16.66% of each htlcs in fees
 		// 167 in fees from first

--- a/src/jit_channel/event.rs
+++ b/src/jit_channel/event.rs
@@ -110,10 +110,6 @@ pub enum LSPS2Event {
 	OpenChannel {
 		/// The node to open channel with.
 		their_network_key: PublicKey,
-		/// The intercepted HTLC amount in msats.
-		inbound_amount_msat: u64,
-		/// The amount the client expects to receive before fees are taken out.
-		expected_outbound_amount_msat: u64,
 		/// The amount to forward after fees.
 		amt_to_forward_msat: u64,
 		/// The fee earned for opening the channel.

--- a/src/transport/message_handler.rs
+++ b/src/transport/message_handler.rs
@@ -446,14 +446,12 @@ where {
 	/// [`Event::HTLCIntercepted`]: lightning::events::Event::HTLCIntercepted
 	/// [`LSPS2Event::OpenChannel`]: crate::jit_channel::LSPS2Event::OpenChannel
 	pub fn htlc_intercepted(
-		&self, scid: u64, intercept_id: InterceptId, inbound_amount_msat: u64,
-		expected_outbound_amount_msat: u64,
+		&self, scid: u64, intercept_id: InterceptId, expected_outbound_amount_msat: u64,
 	) -> Result<(), APIError> {
 		if let Some(lsps2_message_handler) = &self.lsps2_message_handler {
 			lsps2_message_handler.htlc_intercepted(
 				scid,
 				intercept_id,
-				inbound_amount_msat,
 				expected_outbound_amount_msat,
 			)?;
 		}


### PR DESCRIPTION
This should be based on top of lightningdevkit/lightning-liquidity#20 but I can't open a PR on top of a PR in my repo over here.  So if reviewing this please just look at the last commit.  Once lightningdevkit/lightning-liquidity#20 is merged I will rebase this PR.

When a payment is made that initiates a JIT channel open it is possible the payer uses MPP. If `payment_size_msat` is specified by client then the LSP needs to allow for MPP to be used.

This means when an HTLC is intercepted we need to collect the payment parts and only open the channel once the total amount we collected is enough to cover the original payment_size.

This PR introduces a Vec of `InterceptedHTLC`'s into the OutboundJITChannelState to track these.  There's a new `OutboundJITChannelState::PendingPaymentReceived` state that can be entered if MPP is supported and the first htlc_intercepted is not large enough to cover the requested payment_size.

It is possible to skip this state if MPP is not supported or the first payment is large enough.

The spec does not specify how the LSP should extract the fee from the collection of HTLCs received as part of the MPP.  In this pass I iterate over all parts and greedily take as much of the fee I can from each HTLC until the total fee amount has been accounted for.  I could imagine another strategy that tries to minimize the number of HTLCs that are used to pay the fee (sorting from largest to smallest and performing same strategy but I'm not sure it matters.

It's also unclear to me whether batch forwarding all of the HTLCs at once could run into problems in practice.