### PR TITLE
Add missing error handling

### DIFF
--- a/src/jit_channel/event.rs
+++ b/src/jit_channel/event.rs
@@ -20,7 +20,11 @@ pub enum LSPS2Event {
 	/// You must calculate the parameters for this client and pass them to
 	/// [`LiquidityManager::opening_fee_params_generated`].
 	///
+	/// If an unrecognized or stale token is provided you can use
+	/// `[LiquidityManager::invalid_token_provided`] to error the request.
+	///
 	/// [`LiquidityManager::opening_fee_params_generated`]: crate::LiquidityManager::opening_fee_params_generated
+	/// [`LiquidityManager::invalid_token_provided`]: crate::LiquidityManager::invalid_token_provided
 	GetInfo {
 		/// An identifier that must be passed to [`LiquidityManager::opening_fee_params_generated`].
 		///

--- a/src/jit_channel/msgs.rs
+++ b/src/jit_channel/msgs.rs
@@ -14,6 +14,7 @@ pub(crate) const LSPS2_GET_INFO_METHOD_NAME: &str = "lsps2.get_info";
 pub(crate) const LSPS2_BUY_METHOD_NAME: &str = "lsps2.buy";
 
 pub(crate) const LSPS2_GET_INFO_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
+pub(crate) const LSPS2_GET_INFO_REQUEST_UNRECOGNIZED_OR_STALE_TOKEN_ERROR_CODE: i32 = 2;
 
 pub(crate) const LSPS2_BUY_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
 pub(crate) const LSPS2_BUY_REQUEST_INVALID_OPENING_FEE_PARAMS_ERROR_CODE: i32 = 2;

--- a/src/jit_channel/msgs.rs
+++ b/src/jit_channel/msgs.rs
@@ -13,6 +13,8 @@ pub(crate) const LSPS2_GET_VERSIONS_METHOD_NAME: &str = "lsps2.get_versions";
 pub(crate) const LSPS2_GET_INFO_METHOD_NAME: &str = "lsps2.get_info";
 pub(crate) const LSPS2_BUY_METHOD_NAME: &str = "lsps2.buy";
 
+pub(crate) const LSPS2_GET_INFO_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
+
 pub(crate) const LSPS2_BUY_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
 pub(crate) const LSPS2_BUY_REQUEST_INVALID_OPENING_FEE_PARAMS_ERROR_CODE: i32 = 2;
 pub(crate) const LSPS2_BUY_REQUEST_PAYMENT_SIZE_TOO_SMALL_ERROR_CODE: i32 = 3;

--- a/src/transport/message_handler.rs
+++ b/src/transport/message_handler.rs
@@ -361,6 +361,24 @@ where {
 		}
 	}
 
+	/// Used by LSP to inform a client requesting a JIT Channel the token they used is invalid.
+	///
+	/// Should be called in response to receiving a [`LSPS2Event::GetInfo`] event.
+	///
+	/// [`LSPS2Event::GetInfo`]: crate::jit_channel::LSPS2Event::GetInfo
+	pub fn invalid_token_provided(
+		&self, counterparty_node_id: PublicKey, request_id: RequestId,
+	) -> Result<(), APIError> {
+		if let Some(lsps2_message_handler) = &self.lsps2_message_handler {
+			lsps2_message_handler.invalid_token_provided(counterparty_node_id, request_id)
+		} else {
+			Err(APIError::APIMisuseError {
+				err: "JIT Channels were not configured when LSPManager was instantiated"
+					.to_string(),
+			})
+		}
+	}
+
 	/// Used by LSP to provide fee parameters to a client requesting a JIT Channel.
 	///
 	/// Should be called in response to receiving a [`LSPS2Event::GetInfo`] event.


### PR DESCRIPTION
We are missing a lot of the actual error codes/responses that the specification specifies.  This PR attempts to add support for the missing ones.

At the moment it's just the two get_info errors.