### PR TITLE
Update LSPS2's `compute_opening_fee`

### DIFF
--- a/src/jit_channel/channel_manager.rs
+++ b/src/jit_channel/channel_manager.rs
@@ -224,7 +224,7 @@ impl OutboundJITChannelState {
 				compute_opening_fee(
 					expected_outbound_amount_msat,
 					opening_fee_params.min_fee_msat,
-					opening_fee_params.proportional,
+					opening_fee_params.proportional.into(),
 				).map(|opening_fee_msat| OutboundJITChannelState::PendingChannelOpen {
 					intercept_id,
 					opening_fee_msat,
@@ -994,7 +994,7 @@ where
 			match compute_opening_fee(
 				payment_size_msat,
 				params.opening_fee_params.min_fee_msat,
-				params.opening_fee_params.proportional,
+				params.opening_fee_params.proportional.into(),
 			) {
 				Some(opening_fee) => {
 					if opening_fee >= payment_size_msat {

--- a/src/jit_channel/utils.rs
+++ b/src/jit_channel/utils.rs
@@ -42,11 +42,11 @@ pub fn is_valid_opening_fee_params(
 ///
 /// See the [`specification`](https://github.com/BitcoinAndLightningLayerSpecs/lsp/tree/main/LSPS2#computing-the-opening_fee) for more details.
 pub fn compute_opening_fee(
-	payment_size_msat: u64, opening_fee_min_fee_msat: u64, opening_fee_proportional: u32,
+	payment_size_msat: u64, opening_fee_min_fee_msat: u64, opening_fee_proportional: u64,
 ) -> Option<u64> {
-	let t1 = payment_size_msat.checked_mul(opening_fee_proportional.into())?;
-	let t2 = t1.checked_add(999999)?;
-	let t3 = t2.checked_div(1000000)?;
-	let t4 = std::cmp::max(t3, opening_fee_min_fee_msat);
-	Some(t4)
+	payment_size_msat
+		.checked_mul(opening_fee_proportional)
+		.and_then(|f| f.checked_add(999999))
+		.and_then(|f| f.checked_div(1000000))
+		.map(|f| std::cmp::max(f, opening_fee_min_fee_msat))
 }


### PR DESCRIPTION
While the intial Rust code proposed in the spec wasn't wrong, it has since been updated to a more idiomatic version. Here, we update our methods accordingly.