### PR TITLE
expose compute_opening_fee

### DIFF
--- a/src/jit_channel/mod.rs
+++ b/src/jit_channel/mod.rs
@@ -17,3 +17,4 @@ pub(crate) mod utils;
 
 pub use event::LSPS2Event;
 pub use msgs::{BuyResponse, GetInfoResponse, OpeningFeeParams, RawOpeningFeeParams};
+pub use utils::compute_opening_fee;


### PR DESCRIPTION
I need to use this in the mutiny implementation of LSPS2 to be able to calculate the fee to present to the wallet user.