### PR TITLE
Bump MSRV to 1.63, edition to 2021

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         include:
           - toolchain: stable
             check-fmt: true
-          - toolchain: 1.48.0
+          - toolchain: 1.63.0
             platform: ubuntu-latest
             msrv: true
 
@@ -28,14 +28,7 @@ jobs:
       - name: Pin crates for MSRV
         if: matrix.msrv
         run: |
-          # The serde_json crate switched to Rust edition 2021 starting with v1.0.101, i.e., has MSRV of 1.56
-          cargo update -p serde_json --precise "1.0.99" --verbose
-          cargo update -p serde --precise "1.0.156" --verbose
-          # The quote crate switched to Rust edition 2021 starting with v1.0.31, i.e., has MSRV of 1.56
-          cargo update -p quote --precise "1.0.30" --verbose
-          # The proc-macro2 crate switched to Rust edition 2021 starting with v1.0.66, i.e., has MSRV of 1.56
-          cargo update -p proc-macro2 --precise "1.0.65" --verbose
-          cargo update -p chrono --precise "0.4.24" --verbose
+          # No need to pin currently
       - name: Cargo check
         run: cargo check --release
       - name: Check documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lightning-liquidity"
 version = "0.1.0"
 authors = ["John Cantrell <johncantrell97@gmail.com>", "Elias Rohrer <dev@tnull.de>"]
-edition = "2018"
+edition = "2021"
 description = "Types and primitives to integrate a spec-compliant LSP with an LDK-based node."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,8 @@
 //! # `lightning-liquidity`
 //! Types and primitives to integrate a spec-compliant LSP with an LDK-based node.
 #![deny(missing_docs)]
-#![deny(broken_intra_doc_links)]
-#![deny(private_intra_doc_links)]
+#![deny(rustdoc::broken_intra_doc_links)]
+#![deny(rustdoc::private_intra_doc_links)]
 #![allow(bare_trait_objects)]
 #![allow(ellipsis_inclusive_range_patterns)]
 #![allow(clippy::drop_non_drop)]


### PR DESCRIPTION
Based on #48. 

As `rust-lightning` will soon bump its MSRV to 1.63, we do the same here.