### PR TITLE
expose message type id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,3 +26,4 @@ pub mod lsps2;
 mod utils;
 
 pub use lsps0::message_handler::{JITChannelsConfig, LiquidityManager, LiquidityProviderConfig};
+pub use lsps0::msgs::LSPS_MESSAGE_TYPE_ID;


### PR DESCRIPTION
this became hidden in the refactor. it is needed when a user is writing their custom message handler.