### PR TITLE
Make crate `no_std` compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
         if: matrix.check-fmt
         run: rustup component add rustfmt && cargo fmt --all -- --check
       - name: Test on Rust ${{ matrix.toolchain }}
-        run: cargo test
-      - name: Test on Rust ${{ matrix.toolchain }} with LSPS1 support
-        run: RUSTFLAGS="--cfg lsps1" cargo test
+        run: |
+          cargo test
+          RUSTFLAGS="--cfg lsps1" cargo test
+      - name: Test on Rust ${{ matrix.toolchain }} with no-std support
+        run: |
+          cargo test --no-default-features --features no-std
+          RUSTFLAGS="--cfg lsps1" cargo test --no-default-features --features no-std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,12 +7,18 @@ description = "Types and primitives to integrate a spec-compliant LSP with an LD
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["std"]
+std = ["lightning/std", "bitcoin/std"]
+no-std = ["hashbrown", "lightning/no-std", "bitcoin/no-std", "core2/alloc"]
+
 [dependencies]
-lightning = { version = "0.0.118", default-features = false, features = ["max_level_trace", "std"] }
+lightning = { version = "0.0.118", default-features = false, features = ["max_level_trace"] }
 lightning-invoice = "0.26.0"
+bitcoin = { version = "0.29.0", default-features = false }
+hashbrown = { version = "0.8", optional = true }
+core2 = { version = "0.3.0", optional = true, default-features = false }
 
-bitcoin = "0.29.0"
-
-chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,33 @@
 #![allow(ellipsis_inclusive_range_patterns)]
 #![allow(clippy::drop_non_drop)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(not(any(feature = "std", feature = "no-std")))]
+compile_error!("at least one of the `std` or `no-std` features must be enabled");
+
+#[macro_use]
+extern crate alloc;
+
+mod prelude {
+	#[cfg(feature = "hashbrown")]
+	extern crate hashbrown;
+
+	#[cfg(feature = "hashbrown")]
+	pub use self::hashbrown::{hash_map, HashMap, HashSet};
+	pub use alloc::{boxed::Box, collections::VecDeque, string::String, vec, vec::Vec};
+	#[cfg(not(feature = "hashbrown"))]
+	pub use std::collections::{hash_map, HashMap, HashSet};
+
+	pub use alloc::borrow::ToOwned;
+	pub use alloc::string::ToString;
+}
 
 pub mod events;
 mod lsps0;
 #[cfg(lsps1)]
 mod lsps1;
 pub mod lsps2;
+mod sync;
 mod utils;
 
 pub use lsps0::message_handler::{JITChannelsConfig, LiquidityManager, LiquidityProviderConfig};

--- a/src/lsps0/msgs.rs
+++ b/src/lsps0/msgs.rs
@@ -7,16 +7,19 @@ use crate::lsps2::msgs::{
 	LSPS2Message, LSPS2Request, LSPS2Response, LSPS2_BUY_METHOD_NAME, LSPS2_GET_INFO_METHOD_NAME,
 	LSPS2_GET_VERSIONS_METHOD_NAME,
 };
+use crate::prelude::{HashMap, String, ToString, Vec};
+
 use lightning::impl_writeable_msg;
 use lightning::ln::wire;
+
 use serde::de;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::json;
-use std::collections::HashMap;
-use std::convert::TryFrom;
-use std::fmt;
+
+use core::convert::TryFrom;
+use core::fmt;
 
 const LSPS_MESSAGE_SERIALIZED_STRUCT_NAME: &str = "LSPSMessage";
 const JSONRPC_FIELD_KEY: &str = "jsonrpc";

--- a/src/lsps0/protocol.rs
+++ b/src/lsps0/protocol.rs
@@ -1,16 +1,19 @@
-use bitcoin::secp256k1::PublicKey;
-use lightning::ln::msgs::{ErrorAction, LightningError};
-use lightning::sign::EntropySource;
-use lightning::util::logger::Level;
-use std::ops::Deref;
-use std::sync::{Arc, Mutex};
-
 use crate::lsps0::message_handler::ProtocolMessageHandler;
 use crate::lsps0::msgs::{
 	LSPS0Message, LSPS0Request, LSPS0Response, LSPSMessage, ListProtocolsRequest,
 	ListProtocolsResponse, RequestId, ResponseError,
 };
+use crate::prelude::Vec;
+use crate::sync::{Arc, Mutex};
 use crate::utils;
+
+use lightning::ln::msgs::{ErrorAction, LightningError};
+use lightning::sign::EntropySource;
+use lightning::util::logger::Level;
+
+use bitcoin::secp256k1::PublicKey;
+
+use core::ops::Deref;
 
 pub struct LSPS0MessageHandler<ES: Deref>
 where
@@ -104,7 +107,8 @@ where
 #[cfg(test)]
 mod tests {
 
-	use std::sync::Arc;
+	use alloc::string::ToString;
+	use alloc::sync::Arc;
 
 	use super::*;
 

--- a/src/lsps1/event.rs
+++ b/src/lsps1/event.rs
@@ -1,9 +1,11 @@
 #![allow(missing_docs)]
 
-use bitcoin::secp256k1::PublicKey;
-
 use super::msgs::{ChannelInfo, OptionsSupported, Order, OrderId, Payment};
+
 use crate::lsps0::msgs::RequestId;
+use crate::prelude::String;
+
+use bitcoin::secp256k1::PublicKey;
 
 /// An "Event" which you should probably take some action in response to.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/lsps1/msgs.rs
+++ b/src/lsps1/msgs.rs
@@ -1,9 +1,11 @@
-use chrono::Utc;
-use std::convert::TryFrom;
+use crate::lsps0::msgs::{LSPSMessage, RequestId, ResponseError};
+use crate::prelude::{String, Vec};
 
 use serde::{Deserialize, Serialize};
 
-use crate::lsps0::msgs::{LSPSMessage, RequestId, ResponseError};
+use chrono::Utc;
+
+use core::convert::TryFrom;
 
 pub(crate) const LSPS1_GET_INFO_METHOD_NAME: &str = "lsps1.get_info";
 pub(crate) const LSPS1_CREATE_ORDER_METHOD_NAME: &str = "lsps1.create_order";

--- a/src/lsps2/event.rs
+++ b/src/lsps2/event.rs
@@ -7,10 +7,11 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-use bitcoin::secp256k1::PublicKey;
-
 use super::msgs::OpeningFeeParams;
 use crate::lsps0::msgs::RequestId;
+use crate::prelude::{String, Vec};
+
+use bitcoin::secp256k1::PublicKey;
 
 /// An event which you should probably take some action in response to.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/lsps2/msgs.rs
+++ b/src/lsps2/msgs.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
@@ -7,6 +7,7 @@ use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
 use crate::lsps0::msgs::{LSPSMessage, RequestId, ResponseError};
+use crate::prelude::{String, Vec};
 use crate::utils;
 
 pub(crate) const LSPS2_GET_VERSIONS_METHOD_NAME: &str = "lsps2.get_versions";
@@ -304,6 +305,8 @@ mod tests {
 	}
 
 	#[test]
+	#[cfg(feature = "std")]
+	// TODO: We need to find a way to check expiry times in no-std builds.
 	fn expired_params_produces_invalid_params() {
 		let min_fee_msat = 100;
 		let proportional = 21;

--- a/src/lsps2/utils.rs
+++ b/src/lsps2/utils.rs
@@ -1,28 +1,32 @@
+use crate::lsps2::msgs::OpeningFeeParams;
+use crate::utils;
+
 use bitcoin::hashes::hmac::{Hmac, HmacEngine};
 use bitcoin::hashes::sha256::Hash as Sha256;
 use bitcoin::hashes::{Hash, HashEngine};
 
-use std::convert::TryInto;
+#[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
-
-use crate::lsps2::msgs::OpeningFeeParams;
-use crate::utils;
 
 /// Determines if the given parameters are valid given the secret used to generate the promise.
 pub fn is_valid_opening_fee_params(
 	fee_params: &OpeningFeeParams, promise_secret: &[u8; 32],
 ) -> bool {
-	let seconds_since_epoch = SystemTime::now()
-		.duration_since(UNIX_EPOCH)
-		.expect("system clock to be ahead of the unix epoch")
-		.as_secs();
-	let valid_until_seconds_since_epoch = fee_params
-		.valid_until
-		.timestamp()
-		.try_into()
-		.expect("expiration to be ahead of unix epoch");
-	if seconds_since_epoch > valid_until_seconds_since_epoch {
-		return false;
+	#[cfg(feature = "std")]
+	{
+		// TODO: We need to find a way to check expiry times in no-std builds.
+		let seconds_since_epoch = SystemTime::now()
+			.duration_since(UNIX_EPOCH)
+			.expect("system clock to be ahead of the unix epoch")
+			.as_secs();
+		let valid_until_seconds_since_epoch = fee_params
+			.valid_until
+			.timestamp()
+			.try_into()
+			.expect("expiration to be ahead of unix epoch");
+		if seconds_since_epoch > valid_until_seconds_since_epoch {
+			return false;
+		}
 	}
 
 	let mut hmac = HmacEngine::<Sha256>::new(promise_secret);
@@ -48,5 +52,5 @@ pub fn compute_opening_fee(
 		.checked_mul(opening_fee_proportional)
 		.and_then(|f| f.checked_add(999999))
 		.and_then(|f| f.checked_div(1000000))
-		.map(|f| std::cmp::max(f, opening_fee_min_fee_msat))
+		.map(|f| core::cmp::max(f, opening_fee_min_fee_msat))
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,0 +1,7 @@
+#[cfg(feature = "std")]
+pub use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+#[cfg(not(feature = "std"))]
+mod nostd_sync;
+#[cfg(not(feature = "std"))]
+pub use nostd_sync::*;

--- a/src/sync/nostd_sync.rs
+++ b/src/sync/nostd_sync.rs
@@ -1,0 +1,102 @@
+//! This file was copied from `rust-lightning`.
+pub use ::alloc::sync::Arc;
+use core::cell::{Ref, RefCell, RefMut};
+use core::ops::{Deref, DerefMut};
+
+pub type LockResult<Guard> = Result<Guard, ()>;
+
+pub struct Mutex<T: ?Sized> {
+	inner: RefCell<T>,
+}
+
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MutexGuard<'a, T: ?Sized + 'a> {
+	lock: RefMut<'a, T>,
+}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.lock.deref()
+	}
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+	fn deref_mut(&mut self) -> &mut T {
+		self.lock.deref_mut()
+	}
+}
+
+impl<T> Mutex<T> {
+	pub fn new(inner: T) -> Mutex<T> {
+		Mutex { inner: RefCell::new(inner) }
+	}
+
+	pub fn lock<'a>(&'a self) -> LockResult<MutexGuard<'a, T>> {
+		Ok(MutexGuard { lock: self.inner.borrow_mut() })
+	}
+
+	pub fn try_lock<'a>(&'a self) -> LockResult<MutexGuard<'a, T>> {
+		Ok(MutexGuard { lock: self.inner.borrow_mut() })
+	}
+
+	pub fn into_inner(self) -> LockResult<T> {
+		Ok(self.inner.into_inner())
+	}
+}
+
+pub struct RwLock<T: ?Sized> {
+	inner: RefCell<T>,
+}
+
+pub struct RwLockReadGuard<'a, T: ?Sized + 'a> {
+	lock: Ref<'a, T>,
+}
+
+pub struct RwLockWriteGuard<'a, T: ?Sized + 'a> {
+	lock: RefMut<'a, T>,
+}
+
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.lock.deref()
+	}
+}
+
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+	type Target = T;
+
+	fn deref(&self) -> &T {
+		&self.lock.deref()
+	}
+}
+
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+	fn deref_mut(&mut self) -> &mut T {
+		self.lock.deref_mut()
+	}
+}
+
+impl<T> RwLock<T> {
+	pub fn new(inner: T) -> RwLock<T> {
+		RwLock { inner: RefCell::new(inner) }
+	}
+
+	pub fn read<'a>(&'a self) -> LockResult<RwLockReadGuard<'a, T>> {
+		Ok(RwLockReadGuard { lock: self.inner.borrow() })
+	}
+
+	pub fn write<'a>(&'a self) -> LockResult<RwLockWriteGuard<'a, T>> {
+		Ok(RwLockWriteGuard { lock: self.inner.borrow_mut() })
+	}
+
+	pub fn try_write<'a>(&'a self) -> LockResult<RwLockWriteGuard<'a, T>> {
+		match self.inner.try_borrow_mut() {
+			Ok(lock) => Ok(RwLockWriteGuard { lock }),
+			Err(_) => Err(()),
+		}
+	}
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,10 @@
 use bitcoin::secp256k1::PublicKey;
+use core::{fmt::Write, ops::Deref};
+use lightning::io;
 use lightning::sign::EntropySource;
-use std::{fmt::Write, ops::Deref};
 
 use crate::lsps0::msgs::RequestId;
+use crate::prelude::{String, Vec};
 
 /// Maximum transaction index that can be used in a `short_channel_id`.
 /// This value is based on the 3-bytes available for tx index.
@@ -89,11 +91,11 @@ pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
 	}
 }
 
-pub fn parse_pubkey(pubkey_str: &str) -> Result<PublicKey, std::io::Error> {
+pub fn parse_pubkey(pubkey_str: &str) -> Result<PublicKey, io::Error> {
 	let pubkey = to_compressed_pubkey(pubkey_str);
 	if pubkey.is_none() {
-		return Err(std::io::Error::new(
-			std::io::ErrorKind::Other,
+		return Err(io::Error::new(
+			io::ErrorKind::Other,
 			"ERROR: unable to parse given pubkey for node",
 		));
 	}


### PR DESCRIPTION
Fixes lightningdevkit/lightning-liquidity#29.

Copying the pattern from the `lightning` crate, we re-export `alloc`/`hashbrown` or `std` depending on whether the `std` feature is set. We also copy some `sync` types from the `lightning` crate that are `no-std` compatible.

Moreover, we check no-std compatibility in CI and, since we already touched most of them, reorder and cleanup the `use` statements in all modules.

One thing we don't tackle in this PR is validating the expiry times of `OpeningFeeParams` in `no-std`. This is now tracked  separately in https://github.com/lightningdevkit/rust-lightning/issues/3471.