### PR TITLE
Add initial `proptest` to check forwarding amount calculation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Pin crates for MSRV
         if: matrix.msrv
         run: |
-          # No need to pin currently
+          cargo update -p proptest --precise "1.2.0" --verbose # proptest 1.3.0 requires rustc 1.64.0
       - name: Cargo check
         run: cargo check --release
       - name: Check documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ core2 = { version = "0.3.0", optional = true, default-features = false }
 chrono = { version = "0.4", default-features = false, features = ["serde", "alloc"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/proptest-regressions/lsps2/channel_manager.txt
+++ b/proptest-regressions/lsps2/channel_manager.txt
@@ -1,0 +1,6 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.

--- a/src/lsps2/utils.rs
+++ b/src/lsps2/utils.rs
@@ -54,3 +54,29 @@ pub fn compute_opening_fee(
 		.and_then(|f| f.checked_div(1000000))
 		.map(|f| core::cmp::max(f, opening_fee_min_fee_msat))
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use proptest::prelude::*;
+
+	const MAX_VALUE_MSAT: u64 = 21_000_000_0000_0000_000;
+
+	fn arb_opening_fee_params() -> impl Strategy<Value = (u64, u64, u64)> {
+		(0u64..MAX_VALUE_MSAT, 0u64..MAX_VALUE_MSAT, 0u64..MAX_VALUE_MSAT)
+	}
+
+	proptest! {
+		#[test]
+		fn test_compute_opening_fee((payment_size_msat, opening_fee_min_fee_msat, opening_fee_proportional) in arb_opening_fee_params()) {
+			if let Some(res) = compute_opening_fee(payment_size_msat, opening_fee_min_fee_msat, opening_fee_proportional) {
+				assert!(res >= opening_fee_min_fee_msat);
+				assert_eq!(res as f32, (payment_size_msat as f32 * opening_fee_proportional as f32));
+			} else {
+				// Check we actually overflowed.
+				let max_value = u64::MAX as u128;
+				assert!((payment_size_msat as u128 * opening_fee_proportional as u128) > max_value);
+			}
+		}
+	}
+}


### PR DESCRIPTION
~~Based on lightningdevkit/lightning-liquidity#53~~, fixes lightningdevkit/lightning-liquidity#45.

We introduce an initial property-based test to check `calculate_amount_to_forward_per_htlc`. We also adapt the latter to be less susceptible to over/underflows.