### PR TITLE
Drop `APeerManager` dependency and replace with `process_msgs_callback`

### DIFF
--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -1,14 +1,10 @@
 //! Holds types and traits used to implement message queues for [`LSPSMessage`]s.
 
 use crate::lsps0::msgs::LSPSMessage;
-use crate::prelude::{Vec, VecDeque};
-use crate::sync::Mutex;
-
-use lightning::ln::peer_handler::APeerManager;
+use crate::prelude::{Box, Vec, VecDeque};
+use crate::sync::{Mutex, RwLock};
 
 use bitcoin::secp256k1::PublicKey;
-
-use core::ops::Deref;
 
 /// Represents a simple message queue that the LSPS message handlers use to send messages to a given counterparty.
 pub trait MessageQueue {
@@ -22,45 +18,36 @@ pub trait MessageQueue {
 /// The default [`MessageQueue`] Implementation used by [`LiquidityManager`].
 ///
 /// [`LiquidityManager`]: crate::LiquidityManager
-pub struct DefaultMessageQueue<PM: Deref>
-where
-	PM::Target: APeerManager,
-{
+pub struct DefaultMessageQueue {
 	queue: Mutex<VecDeque<(PublicKey, LSPSMessage)>>,
-	peer_manager: Mutex<Option<PM>>,
+	process_msgs_callback: RwLock<Option<Box<dyn Fn() + Send + Sync + 'static>>>,
 }
 
-impl<PM: Deref> DefaultMessageQueue<PM>
-where
-	PM::Target: APeerManager,
-{
+impl DefaultMessageQueue {
 	pub(crate) fn new() -> Self {
 		let queue = Mutex::new(VecDeque::new());
-		let peer_manager = Mutex::new(None);
-		Self { queue, peer_manager }
+		let process_msgs_callback = RwLock::new(None);
+		Self { queue, process_msgs_callback }
+	}
+
+	pub(crate) fn set_process_msgs_callback(&self, callback: impl Fn() + Send + Sync + 'static) {
+		*self.process_msgs_callback.write().unwrap() = Some(Box::new(callback));
 	}
 
 	pub(crate) fn get_and_clear_pending_msgs(&self) -> Vec<(PublicKey, LSPSMessage)> {
 		self.queue.lock().unwrap().drain(..).collect()
 	}
-
-	pub(crate) fn set_peer_manager(&self, peer_manager: PM) {
-		*self.peer_manager.lock().unwrap() = Some(peer_manager);
-	}
 }
 
-impl<PM: Deref> MessageQueue for DefaultMessageQueue<PM>
-where
-	PM::Target: APeerManager,
-{
+impl MessageQueue for DefaultMessageQueue {
 	fn enqueue(&self, counterparty_node_id: &PublicKey, msg: LSPSMessage) {
 		{
 			let mut queue = self.queue.lock().unwrap();
 			queue.push_back((*counterparty_node_id, msg));
 		}
 
-		if let Some(peer_manager) = self.peer_manager.lock().unwrap().as_ref() {
-			peer_manager.as_ref().process_events();
+		if let Some(process_msgs_callback) = self.process_msgs_callback.read().unwrap().as_ref() {
+			(process_msgs_callback)()
 		}
 	}
 }


### PR DESCRIPTION
Fixes #72.

Previously, `LiquidityManager` (or at least its internal message queue) was holding a reference to `PeerManager`/`impl APeerManager` in order to be able to trigger message processing after new messages were enqueued.

However, this had two major drawbacks: firstly, it introduced an ugly (and hard to resolve) cycle in the type definitions as `PeerManager` depends on `CustomMessageHandler`, which in this case is `LiquidityManager`, itself depending on said `PeerManager` reference. Secondly, it introduced the complex `PeerManager` LDK object to the LSPS implementation which is otherwise not that depedent on LDK's internal types.

To resolve these issues, we heere replace the dependency on `PeerManager`/`impl APeerManager` with a simple generic callback that will be called every time new messages are enqueued.

Looking for feedback here. As a second step we could consider dropping the `MessageQueue` trait which was introduced as part of the prior refactor that moved the `APeerManager` bound from each individual message handler to the `DefaultMessageQueue`.