### PR TITLE
Use `RUSTDOCFLAGS` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           cargo doc --release
           cargo doc --no-default-features --features no-std
-          RUSTFLAGS="--cfg lsps1" cargo doc --release
-          RUSTFLAGS="--cfg lsps1" cargo doc --no-default-features --features no-std
+          RUSTDOCFLAGS="--cfg lsps1" cargo doc --release
+          RUSTDOCFLAGS="--cfg lsps1" cargo doc --no-default-features --features no-std
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Check formatting


### PR DESCRIPTION
Unfortunately, `cargo doc` doesn't use `RUSTFLAGS`, which made our `lsps1`-cfg-gated CI check useless so far. Here, we fix this by using `RUSTDOCFLAGS` instead.