### PR TITLE
Use both `RUSTFLAGS` *and* `RUSTDOCFLAGS` in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           cargo doc --release
           cargo doc --no-default-features --features no-std
-          RUSTDOCFLAGS="--cfg lsps1" cargo doc --release
-          RUSTDOCFLAGS="--cfg lsps1" cargo doc --no-default-features --features no-std
+          RUSTFLAGS="--cfg lsps1" RUSTDOCFLAGS="--cfg lsps1" cargo doc --release
+          RUSTFLAGS="--cfg lsps1" RUSTDOCFLAGS="--cfg lsps1" cargo doc --no-default-features --features no-std
       - name: Build on Rust ${{ matrix.toolchain }}
         run: cargo build --verbose --color always
       - name: Check formatting


### PR DESCRIPTION
In #78 we previously replaced `cargo doc`'s `RUSTFLAGS` with `RUSTDOCFLAGS` in CI.

Turns out that we need to set both env. variables as otherwise the `broken_intra_doc_links` lint starts complaining.