### PR TITLE
Implement `next_event_async` method polling the event queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1.0.0"
+tokio = { version = "1.35", default-features = false, features = [ "rt-multi-thread", "time", "sync", "macros" ] }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -305,6 +305,13 @@ where {
 		self.pending_events.next_event()
 	}
 
+	/// Asynchronously polls the event queue and returns once the next event is ready.
+	///
+	/// Typically you would spawn a thread or task that calls this in a loop.
+	pub async fn next_event_async(&self) -> Event {
+		self.pending_events.next_event_async().await
+	}
+
 	/// Returns and clears all events without blocking.
 	///
 	/// Typically you would spawn a thread or task that calls this in a loop.


### PR DESCRIPTION
Based on #74.

We implement a way to asynchronously poll the queue for new events,
providing an async alternative to `wait_next_event`.
