### PR TITLE
Drop `MessageQueue` trait and rename `DefaultMessageQueue`

### DIFF
--- a/src/lsps0/client.rs
+++ b/src/lsps0/client.rs
@@ -23,24 +23,22 @@ use bitcoin::secp256k1::PublicKey;
 use core::ops::Deref;
 
 /// A message handler capable of sending and handling LSPS0 messages.
-pub struct LSPS0ClientHandler<ES: Deref, MQ: Deref>
+pub struct LSPS0ClientHandler<ES: Deref>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	entropy_source: ES,
-	pending_messages: MQ,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 }
 
-impl<ES: Deref, MQ: Deref> LSPS0ClientHandler<ES, MQ>
+impl<ES: Deref> LSPS0ClientHandler<ES>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	/// Returns a new instance of [`LSPS0ClientHandler`].
 	pub(crate) fn new(
-		entropy_source: ES, pending_messages: MQ, pending_events: Arc<EventQueue>,
+		entropy_source: ES, pending_messages: Arc<MessageQueue>, pending_events: Arc<EventQueue>,
 	) -> Self {
 		Self { entropy_source, pending_messages, pending_events }
 	}
@@ -85,10 +83,9 @@ where
 	}
 }
 
-impl<ES: Deref, MQ: Deref> ProtocolMessageHandler for LSPS0ClientHandler<ES, MQ>
+impl<ES: Deref> ProtocolMessageHandler for LSPS0ClientHandler<ES>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	type ProtocolMessage = LSPS0Message;
 	const PROTOCOL_NUMBER: Option<u16> = None;
@@ -118,13 +115,13 @@ mod tests {
 	use alloc::sync::Arc;
 
 	use crate::lsps0::msgs::{LSPSMessage, RequestId};
-	use crate::tests::utils::{TestEntropy, TestMessageQueue};
+	use crate::tests::utils::TestEntropy;
 
 	use super::*;
 
 	#[test]
 	fn test_list_protocols() {
-		let pending_messages = Arc::new(TestMessageQueue::new());
+		let pending_messages = Arc::new(MessageQueue::new());
 		let entropy_source = Arc::new(TestEntropy {});
 		let event_queue = Arc::new(EventQueue::new());
 

--- a/src/lsps0/service.rs
+++ b/src/lsps0/service.rs
@@ -19,29 +19,22 @@ use crate::lsps0::msgs::{
 };
 use crate::message_queue::MessageQueue;
 use crate::prelude::Vec;
+use crate::sync::Arc;
 
 use lightning::ln::msgs::{ErrorAction, LightningError};
 use lightning::util::logger::Level;
 
 use bitcoin::secp256k1::PublicKey;
 
-use core::ops::Deref;
-
 /// The main server-side object allowing to send and receive LSPS0 messages.
-pub struct LSPS0ServiceHandler<MQ: Deref>
-where
-	MQ::Target: MessageQueue,
-{
-	pending_messages: MQ,
+pub struct LSPS0ServiceHandler {
+	pending_messages: Arc<MessageQueue>,
 	protocols: Vec<u16>,
 }
 
-impl<MQ: Deref> LSPS0ServiceHandler<MQ>
-where
-	MQ::Target: MessageQueue,
-{
+impl LSPS0ServiceHandler {
 	/// Returns a new instance of [`LSPS0ServiceHandler`].
-	pub(crate) fn new(protocols: Vec<u16>, pending_messages: MQ) -> Self {
+	pub(crate) fn new(protocols: Vec<u16>, pending_messages: Arc<MessageQueue>) -> Self {
 		Self { protocols, pending_messages }
 	}
 
@@ -63,10 +56,7 @@ where
 	}
 }
 
-impl<MQ: Deref> ProtocolMessageHandler for LSPS0ServiceHandler<MQ>
-where
-	MQ::Target: MessageQueue,
-{
+impl ProtocolMessageHandler for LSPS0ServiceHandler {
 	type ProtocolMessage = LSPS0Message;
 	const PROTOCOL_NUMBER: Option<u16> = None;
 
@@ -92,7 +82,6 @@ where
 mod tests {
 
 	use crate::lsps0::msgs::{LSPSMessage, ListProtocolsRequest};
-	use crate::tests::utils::TestMessageQueue;
 	use crate::utils;
 	use alloc::string::ToString;
 	use alloc::sync::Arc;
@@ -102,7 +91,7 @@ mod tests {
 	#[test]
 	fn test_handle_list_protocols_request() {
 		let protocols: Vec<u16> = vec![];
-		let pending_messages = Arc::new(TestMessageQueue::new());
+		let pending_messages = Arc::new(MessageQueue::new());
 
 		let lsps0_handler = Arc::new(LSPS0ServiceHandler::new(protocols, pending_messages.clone()));
 

--- a/src/lsps1/client.rs
+++ b/src/lsps1/client.rs
@@ -216,32 +216,30 @@ impl PeerState {
 }
 
 /// The main object allowing to send and receive LSPS1 messages.
-pub struct LSPS1ClientHandler<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref>
+pub struct LSPS1ClientHandler<ES: Deref, CM: Deref + Clone, C: Deref>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 {
 	entropy_source: ES,
 	channel_manager: CM,
 	chain_source: Option<C>,
-	pending_messages: MQ,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 	config: LSPS1ClientConfig,
 }
 
-impl<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref> LSPS1ClientHandler<ES, CM, MQ, C>
+impl<ES: Deref, CM: Deref + Clone, C: Deref> LSPS1ClientHandler<ES, CM, C>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 	ES::Target: EntropySource,
 {
 	pub(crate) fn new(
-		entropy_source: ES, pending_messages: MQ, pending_events: Arc<EventQueue>,
+		entropy_source: ES, pending_messages: Arc<MessageQueue>, pending_events: Arc<EventQueue>,
 		channel_manager: CM, chain_source: Option<C>, config: LSPS1ClientConfig,
 	) -> Self {
 		Self {
@@ -609,12 +607,11 @@ where
 	}
 }
 
-impl<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref> ProtocolMessageHandler
-	for LSPS1ClientHandler<ES, CM, MQ, C>
+impl<ES: Deref, CM: Deref + Clone, C: Deref> ProtocolMessageHandler
+	for LSPS1ClientHandler<ES, CM, C>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 {
 	type ProtocolMessage = LSPS1Message;

--- a/src/lsps1/service.rs
+++ b/src/lsps1/service.rs
@@ -136,32 +136,30 @@ impl PeerState {
 }
 
 /// The main object allowing to send and receive LSPS1 messages.
-pub struct LSPS1ServiceHandler<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref>
+pub struct LSPS1ServiceHandler<ES: Deref, CM: Deref + Clone, C: Deref>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 {
 	entropy_source: ES,
 	channel_manager: CM,
 	chain_source: Option<C>,
-	pending_messages: MQ,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 	config: LSPS1ServiceConfig,
 }
 
-impl<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref> LSPS1ServiceHandler<ES, CM, MQ, C>
+impl<ES: Deref, CM: Deref + Clone, C: Deref> LSPS1ServiceHandler<ES, CM, C>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 	ES::Target: EntropySource,
 {
 	pub(crate) fn new(
-		entropy_source: ES, pending_messages: MQ, pending_events: Arc<EventQueue>,
+		entropy_source: ES, pending_messages: Arc<MessageQueue>, pending_events: Arc<EventQueue>,
 		channel_manager: CM, chain_source: Option<C>, config: LSPS1ServiceConfig,
 	) -> Self {
 		Self {
@@ -422,12 +420,11 @@ where
 	}
 }
 
-impl<ES: Deref, CM: Deref + Clone, MQ: Deref, C: Deref> ProtocolMessageHandler
-	for LSPS1ServiceHandler<ES, CM, MQ, C>
+impl<ES: Deref, CM: Deref + Clone, C: Deref> ProtocolMessageHandler
+	for LSPS1ServiceHandler<ES, CM, C>
 where
 	ES::Target: EntropySource,
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 	C::Target: Filter,
 {
 	type ProtocolMessage = LSPS1Message;

--- a/src/lsps2/client.rs
+++ b/src/lsps2/client.rs
@@ -200,26 +200,24 @@ impl PeerState {
 }
 
 /// The main object allowing to send and receive LSPS2 messages.
-pub struct LSPS2ClientHandler<ES: Deref, MQ: Deref>
+pub struct LSPS2ClientHandler<ES: Deref>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	entropy_source: ES,
-	pending_messages: MQ,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 	_config: LSPS2ClientConfig,
 }
 
-impl<ES: Deref, MQ: Deref> LSPS2ClientHandler<ES, MQ>
+impl<ES: Deref> LSPS2ClientHandler<ES>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	/// Constructs an `LSPS2ClientHandler`.
 	pub(crate) fn new(
-		entropy_source: ES, pending_messages: MQ, pending_events: Arc<EventQueue>,
+		entropy_source: ES, pending_messages: Arc<MessageQueue>, pending_events: Arc<EventQueue>,
 		config: LSPS2ClientConfig,
 	) -> Self {
 		Self {
@@ -592,10 +590,9 @@ where
 	}
 }
 
-impl<ES: Deref, MQ: Deref> ProtocolMessageHandler for LSPS2ClientHandler<ES, MQ>
+impl<ES: Deref> ProtocolMessageHandler for LSPS2ClientHandler<ES>
 where
 	ES::Target: EntropySource,
-	MQ::Target: MessageQueue,
 {
 	type ProtocolMessage = LSPS2Message;
 	const PROTOCOL_NUMBER: Option<u16> = Some(2);

--- a/src/lsps2/service.rs
+++ b/src/lsps2/service.rs
@@ -260,27 +260,25 @@ impl PeerState {
 }
 
 /// The main object allowing to send and receive LSPS2 messages.
-pub struct LSPS2ServiceHandler<CM: Deref + Clone, MQ: Deref>
+pub struct LSPS2ServiceHandler<CM: Deref + Clone>
 where
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 {
 	channel_manager: CM,
-	pending_messages: MQ,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 	per_peer_state: RwLock<HashMap<PublicKey, Mutex<PeerState>>>,
 	peer_by_scid: RwLock<HashMap<u64, PublicKey>>,
 	config: LSPS2ServiceConfig,
 }
 
-impl<CM: Deref + Clone, MQ: Deref> LSPS2ServiceHandler<CM, MQ>
+impl<CM: Deref + Clone> LSPS2ServiceHandler<CM>
 where
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 {
 	/// Constructs a `LSPS2ServiceHandler`.
 	pub(crate) fn new(
-		pending_messages: MQ, pending_events: Arc<EventQueue>, channel_manager: CM,
+		pending_messages: Arc<MessageQueue>, pending_events: Arc<EventQueue>, channel_manager: CM,
 		config: LSPS2ServiceConfig,
 	) -> Self {
 		Self {
@@ -742,10 +740,9 @@ where
 	}
 }
 
-impl<CM: Deref + Clone, MQ: Deref> ProtocolMessageHandler for LSPS2ServiceHandler<CM, MQ>
+impl<CM: Deref + Clone> ProtocolMessageHandler for LSPS2ServiceHandler<CM>
 where
 	CM::Target: AChannelManager,
-	MQ::Target: MessageQueue,
 {
 	type ProtocolMessage = LSPS2Message;
 	const PROTOCOL_NUMBER: Option<u16> = Some(2);

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -4,7 +4,7 @@ use crate::lsps0::msgs::{
 	LSPS0Message, LSPSMessage, ProtocolMessageHandler, RawLSPSMessage, LSPS_MESSAGE_TYPE_ID,
 };
 use crate::lsps0::service::LSPS0ServiceHandler;
-use crate::message_queue::{DefaultMessageQueue, MessageQueue};
+use crate::message_queue::MessageQueue;
 
 #[cfg(lsps1)]
 use crate::lsps1::client::{LSPS1ClientConfig, LSPS1ClientHandler};
@@ -83,17 +83,17 @@ where
 	CM::Target: AChannelManager,
 	C::Target: Filter,
 {
-	pending_messages: Arc<DefaultMessageQueue>,
+	pending_messages: Arc<MessageQueue>,
 	pending_events: Arc<EventQueue>,
 	request_id_to_method_map: Mutex<HashMap<String, String>>,
-	lsps0_client_handler: LSPS0ClientHandler<ES, Arc<DefaultMessageQueue>>,
-	lsps0_service_handler: Option<LSPS0ServiceHandler<Arc<DefaultMessageQueue>>>,
+	lsps0_client_handler: LSPS0ClientHandler<ES>,
+	lsps0_service_handler: Option<LSPS0ServiceHandler>,
 	#[cfg(lsps1)]
-	lsps1_service_handler: Option<LSPS1ServiceHandler<ES, CM, Arc<DefaultMessageQueue>, C>>,
+	lsps1_service_handler: Option<LSPS1ServiceHandler<ES, CM, C>>,
 	#[cfg(lsps1)]
-	lsps1_client_handler: Option<LSPS1ClientHandler<ES, CM, Arc<DefaultMessageQueue>, C>>,
-	lsps2_service_handler: Option<LSPS2ServiceHandler<CM, Arc<DefaultMessageQueue>>>,
-	lsps2_client_handler: Option<LSPS2ClientHandler<ES, Arc<DefaultMessageQueue>>>,
+	lsps1_client_handler: Option<LSPS1ClientHandler<ES, CM, C>>,
+	lsps2_service_handler: Option<LSPS2ServiceHandler<CM>>,
+	lsps2_client_handler: Option<LSPS2ClientHandler<ES>>,
 	service_config: Option<LiquidityServiceConfig>,
 	_client_config: Option<LiquidityClientConfig>,
 	best_block: Option<RwLock<BestBlock>>,
@@ -116,7 +116,7 @@ where
 		client_config: Option<LiquidityClientConfig>,
 	) -> Self
 where {
-		let pending_messages = Arc::new(DefaultMessageQueue::new());
+		let pending_messages = Arc::new(MessageQueue::new());
 		let pending_events = Arc::new(EventQueue::new());
 
 		let lsps0_client_handler = LSPS0ClientHandler::new(
@@ -200,42 +200,34 @@ where {
 	}
 
 	/// Returns a reference to the LSPS0 client-side handler.
-	pub fn lsps0_client_handler(&self) -> &LSPS0ClientHandler<ES, Arc<DefaultMessageQueue>> {
+	pub fn lsps0_client_handler(&self) -> &LSPS0ClientHandler<ES> {
 		&self.lsps0_client_handler
 	}
 
 	/// Returns a reference to the LSPS0 server-side handler.
-	pub fn lsps0_service_handler(&self) -> Option<&LSPS0ServiceHandler<Arc<DefaultMessageQueue>>> {
+	pub fn lsps0_service_handler(&self) -> Option<&LSPS0ServiceHandler> {
 		self.lsps0_service_handler.as_ref()
 	}
 
 	/// Returns a reference to the LSPS1 client-side handler.
 	#[cfg(lsps1)]
-	pub fn lsps1_client_handler(
-		&self,
-	) -> Option<&LSPS1ClientHandler<ES, CM, Arc<DefaultMessageQueue>, C>> {
+	pub fn lsps1_client_handler(&self) -> Option<&LSPS1ClientHandler<ES, CM, C>> {
 		self.lsps1_client_handler.as_ref()
 	}
 
 	/// Returns a reference to the LSPS1 server-side handler.
 	#[cfg(lsps1)]
-	pub fn lsps1_service_handler(
-		&self,
-	) -> Option<&LSPS1ServiceHandler<ES, CM, Arc<DefaultMessageQueue>, C>> {
+	pub fn lsps1_service_handler(&self) -> Option<&LSPS1ServiceHandler<ES, CM, C>> {
 		self.lsps1_service_handler.as_ref()
 	}
 
 	/// Returns a reference to the LSPS2 client-side handler.
-	pub fn lsps2_client_handler(
-		&self,
-	) -> Option<&LSPS2ClientHandler<ES, Arc<DefaultMessageQueue>>> {
+	pub fn lsps2_client_handler(&self) -> Option<&LSPS2ClientHandler<ES>> {
 		self.lsps2_client_handler.as_ref()
 	}
 
 	/// Returns a reference to the LSPS2 server-side handler.
-	pub fn lsps2_service_handler(
-		&self,
-	) -> Option<&LSPS2ServiceHandler<CM, Arc<DefaultMessageQueue>>> {
+	pub fn lsps2_service_handler(&self) -> Option<&LSPS2ServiceHandler<CM>> {
 		self.lsps2_service_handler.as_ref()
 	}
 

--- a/src/message_queue.rs
+++ b/src/message_queue.rs
@@ -6,24 +6,15 @@ use crate::sync::{Mutex, RwLock};
 
 use bitcoin::secp256k1::PublicKey;
 
-/// Represents a simple message queue that the LSPS message handlers use to send messages to a given counterparty.
-pub trait MessageQueue {
-	/// Enqueues an LSPS message to be sent to the counterparty with the given node id.
-	///
-	/// Implementations need to take care of message delivery to the counterparty via the
-	/// LSPS0/BOLT8 transport protocol.
-	fn enqueue(&self, counterparty_node_id: &PublicKey, msg: LSPSMessage);
-}
-
 /// The default [`MessageQueue`] Implementation used by [`LiquidityManager`].
 ///
 /// [`LiquidityManager`]: crate::LiquidityManager
-pub struct DefaultMessageQueue {
+pub struct MessageQueue {
 	queue: Mutex<VecDeque<(PublicKey, LSPSMessage)>>,
 	process_msgs_callback: RwLock<Option<Box<dyn Fn() + Send + Sync + 'static>>>,
 }
 
-impl DefaultMessageQueue {
+impl MessageQueue {
 	pub(crate) fn new() -> Self {
 		let queue = Mutex::new(VecDeque::new());
 		let process_msgs_callback = RwLock::new(None);
@@ -37,10 +28,8 @@ impl DefaultMessageQueue {
 	pub(crate) fn get_and_clear_pending_msgs(&self) -> Vec<(PublicKey, LSPSMessage)> {
 		self.queue.lock().unwrap().drain(..).collect()
 	}
-}
 
-impl MessageQueue for DefaultMessageQueue {
-	fn enqueue(&self, counterparty_node_id: &PublicKey, msg: LSPSMessage) {
+	pub(crate) fn enqueue(&self, counterparty_node_id: &PublicKey, msg: LSPSMessage) {
 		{
 			let mut queue = self.queue.lock().unwrap();
 			queue.push_back((*counterparty_node_id, msg));

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -1,35 +1,4 @@
-use crate::lsps0::msgs::LSPSMessage;
-use crate::message_queue::MessageQueue;
-use crate::prelude::{Vec, VecDeque};
-use crate::sync::Mutex;
-
 use lightning::sign::EntropySource;
-
-use bitcoin::secp256k1::PublicKey;
-
-pub(crate) struct TestMessageQueue {
-	queue: Mutex<VecDeque<(PublicKey, LSPSMessage)>>,
-}
-
-impl TestMessageQueue {
-	pub(crate) fn new() -> Self {
-		let queue = Mutex::new(VecDeque::new());
-		Self { queue }
-	}
-
-	pub(crate) fn get_and_clear_pending_msgs(&self) -> Vec<(PublicKey, LSPSMessage)> {
-		self.queue.lock().unwrap().drain(..).collect()
-	}
-}
-
-impl MessageQueue for TestMessageQueue {
-	fn enqueue(&self, counterparty_node_id: &PublicKey, msg: LSPSMessage) {
-		{
-			let mut queue = self.queue.lock().unwrap();
-			queue.push_back((*counterparty_node_id, msg));
-		}
-	}
-}
 
 pub struct TestEntropy {}
 impl EntropySource for TestEntropy {


### PR DESCRIPTION
We previously introduced the `MessageQueue` trait in order to be able to move the `APeerManager` dependency to a single (optional) place. As we now got rid of the type dependency, we may as well drop this intermediary step again, as there is likely no immediate benefit in allowing users to implement their own custom message queues. However, removing the type parameter further cleans up our types and reduces overall complexity.