### PR TITLE
Expose `lsps2/utils.rs`

### DIFF
--- a/src/lsps2/mod.rs
+++ b/src/lsps2/mod.rs
@@ -13,4 +13,4 @@ pub mod client;
 pub mod event;
 pub mod msgs;
 pub mod service;
-pub(crate) mod utils;
+pub mod utils;

--- a/src/lsps2/utils.rs
+++ b/src/lsps2/utils.rs
@@ -1,3 +1,5 @@
+//! Utilities for implementing the LSPS2 standard.
+
 use crate::lsps2::msgs::OpeningFeeParams;
 use crate::utils;
 


### PR DESCRIPTION
Supersedes #51

We expose the LSPS2 utils .. as they are useful and already properly documented for the most part.