### PR TITLE
Remove versioning and cleanup warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Check formatting
         if: matrix.check-fmt
         run: rustup component add rustfmt && cargo fmt --all -- --check
+      - name: Set RUSTFLAGS to deny warnings
+        if: "matrix.toolchain == 'stable'"
+        run: echo "RUSTFLAGS=-D warnings" >> "$GITHUB_ENV"
       - name: Test on Rust ${{ matrix.toolchain }}
         run: |
           cargo test

--- a/src/events.rs
+++ b/src/events.rs
@@ -131,13 +131,12 @@ impl Future for EventFuture {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
-	use crate::lsps0::event::LSPS0ClientEvent;
-	use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
-
 	#[tokio::test]
 	#[cfg(feature = "std")]
 	async fn event_queue_works() {
+		use super::*;
+		use crate::lsps0::event::LSPS0ClientEvent;
+		use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
 		use core::sync::atomic::{AtomicU16, Ordering};
 		use std::sync::Arc;
 		use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,8 @@ mod prelude {
 pub mod events;
 pub mod lsps0;
 #[cfg(lsps1)]
+// TODO: disallow warnings once the implementation is finished
+#[allow(warnings)]
 pub mod lsps1;
 pub mod lsps2;
 mod manager;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ compile_error!("at least one of the `std` or `no-std` features must be enabled")
 extern crate alloc;
 
 mod prelude {
+	#![allow(unused_imports)]
 	#[cfg(feature = "hashbrown")]
 	extern crate hashbrown;
 

--- a/src/lsps0/client.rs
+++ b/src/lsps0/client.rs
@@ -115,7 +115,7 @@ mod tests {
 	use alloc::sync::Arc;
 
 	use crate::lsps0::msgs::{LSPSMessage, RequestId};
-	use crate::tests::utils::TestEntropy;
+	use crate::tests::utils::{self, TestEntropy};
 
 	use super::*;
 

--- a/src/lsps0/msgs.rs
+++ b/src/lsps0/msgs.rs
@@ -9,7 +9,6 @@ use crate::lsps1::msgs::{
 };
 use crate::lsps2::msgs::{
 	LSPS2Message, LSPS2Request, LSPS2Response, LSPS2_BUY_METHOD_NAME, LSPS2_GET_INFO_METHOD_NAME,
-	LSPS2_GET_VERSIONS_METHOD_NAME,
 };
 use crate::prelude::{HashMap, String, ToString, Vec};
 
@@ -294,9 +293,6 @@ impl Serialize for LSPSMessage {
 				jsonrpc_object.serialize_field(JSONRPC_METHOD_FIELD_KEY, request.method())?;
 
 				match request {
-					LSPS2Request::GetVersions(params) => {
-						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
 					LSPS2Request::GetInfo(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
 					}
@@ -309,9 +305,6 @@ impl Serialize for LSPSMessage {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
 
 				match response {
-					LSPS2Response::GetVersions(result) => {
-						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
 					LSPS2Response::GetInfo(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
 					}
@@ -423,14 +416,6 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						LSPS1Request::GetOrder(request),
 					)))
 				}
-				LSPS2_GET_VERSIONS_METHOD_NAME => {
-					let request = serde_json::from_value(params.unwrap_or(json!({})))
-						.map_err(de::Error::custom)?;
-					Ok(LSPSMessage::LSPS2(LSPS2Message::Request(
-						RequestId(id),
-						LSPS2Request::GetVersions(request),
-					)))
-				}
 				LSPS2_GET_INFO_METHOD_NAME => {
 					let request = serde_json::from_value(params.unwrap_or(json!({})))
 						.map_err(de::Error::custom)?;
@@ -469,18 +454,6 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 							)))
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
-						}
-					}
-					LSPS2_GET_VERSIONS_METHOD_NAME => {
-						if let Some(result) = result {
-							let response =
-								serde_json::from_value(result).map_err(de::Error::custom)?;
-							Ok(LSPSMessage::LSPS2(LSPS2Message::Response(
-								RequestId(id),
-								LSPS2Response::GetVersions(response),
-							)))
-						} else {
-							Err(de::Error::custom("Received invalid lsps2.get_versions response."))
 						}
 					}
 					#[cfg(lsps1)]

--- a/src/lsps0/service.rs
+++ b/src/lsps0/service.rs
@@ -82,7 +82,7 @@ impl ProtocolMessageHandler for LSPS0ServiceHandler {
 mod tests {
 
 	use crate::lsps0::msgs::{LSPSMessage, ListProtocolsRequest};
-	use crate::utils;
+	use crate::tests::utils;
 	use alloc::string::ToString;
 	use alloc::sync::Arc;
 

--- a/src/lsps1/event.rs
+++ b/src/lsps1/event.rs
@@ -19,8 +19,6 @@ pub enum LSPS1ClientEvent {
 		/// TODO
 		counterparty_node_id: PublicKey,
 		/// TODO
-		version: u16,
-		/// TODO
 		website: String,
 		/// TODO
 		options_supported: OptionsSupported,

--- a/src/lsps1/msgs.rs
+++ b/src/lsps1/msgs.rs
@@ -16,7 +16,6 @@ pub(crate) const LSPS1_GET_ORDER_METHOD_NAME: &str = "lsps1.get_order";
 pub(crate) const LSPS1_CREATE_ORDER_REQUEST_INVALID_PARAMS_ERROR_CODE: i32 = -32602;
 pub(crate) const LSPS1_CREATE_ORDER_REQUEST_ORDER_MISMATCH_ERROR_CODE: i32 = 1000;
 pub(crate) const LSPS1_CREATE_ORDER_REQUEST_CLIENT_REJECTED_ERROR_CODE: i32 = 1001;
-pub(crate) const LSPS1_CREATE_ORDER_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
 pub(crate) const LSPS1_CREATE_ORDER_REQUEST_INVALID_TOKEN_ERROR_CODE: i32 = 2;
 
 /// The identifier of an order.
@@ -62,8 +61,6 @@ pub struct OptionsSupported {
 /// A response to an [`GetInfoRequest`].
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GetInfoResponse {
-	/// A list of all supported API versions by the LSP.
-	pub supported_versions: Vec<u16>,
 	/// The website of the LSP.
 	pub website: String,
 	/// All options supported by the LSP.
@@ -76,8 +73,6 @@ pub struct GetInfoResponse {
 /// for more information.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CreateOrderRequest {
-	/// TODO: this is superfluous and should likely be removed.
-	pub version: u16,
 	/// The order made.
 	pub order: OrderParams,
 }
@@ -85,8 +80,6 @@ pub struct CreateOrderRequest {
 /// An object representing an LSPS1 channel order.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct OrderParams {
-	/// The API version that the client wants to work with.
-	pub api_version: u16,
 	/// Indicates how many satoshi the LSP will provide on their side.
 	pub lsp_balance_sat: u64,
 	/// Indicates how many satoshi the client will provide on their side.

--- a/src/lsps2/event.rs
+++ b/src/lsps2/event.rs
@@ -87,8 +87,6 @@ pub enum LSPS2ServiceEvent {
 		request_id: RequestId,
 		/// The node id of the client making the information request.
 		counterparty_node_id: PublicKey,
-		/// The protocol version they would like to use.
-		version: u16,
 		/// An optional token that can be used as an API key, coupon code, etc.
 		token: Option<String>,
 	},
@@ -109,8 +107,6 @@ pub enum LSPS2ServiceEvent {
 		request_id: RequestId,
 		/// The client node id that is making this request.
 		counterparty_node_id: PublicKey,
-		/// The version of the protocol they would like to use.
-		version: u16,
 		/// The channel parameters they have selected.
 		opening_fee_params: OpeningFeeParams,
 		/// The size of the initial payment they would like to receive.

--- a/src/lsps2/msgs.rs
+++ b/src/lsps2/msgs.rs
@@ -12,34 +12,18 @@ use crate::lsps0::msgs::{LSPSMessage, RequestId, ResponseError};
 use crate::prelude::{String, Vec};
 use crate::utils;
 
-pub(crate) const LSPS2_GET_VERSIONS_METHOD_NAME: &str = "lsps2.get_versions";
 pub(crate) const LSPS2_GET_INFO_METHOD_NAME: &str = "lsps2.get_info";
 pub(crate) const LSPS2_BUY_METHOD_NAME: &str = "lsps2.buy";
 
-pub(crate) const LSPS2_GET_INFO_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
 pub(crate) const LSPS2_GET_INFO_REQUEST_UNRECOGNIZED_OR_STALE_TOKEN_ERROR_CODE: i32 = 2;
 
-pub(crate) const LSPS2_BUY_REQUEST_INVALID_VERSION_ERROR_CODE: i32 = 1;
 pub(crate) const LSPS2_BUY_REQUEST_INVALID_OPENING_FEE_PARAMS_ERROR_CODE: i32 = 2;
 pub(crate) const LSPS2_BUY_REQUEST_PAYMENT_SIZE_TOO_SMALL_ERROR_CODE: i32 = 3;
 pub(crate) const LSPS2_BUY_REQUEST_PAYMENT_SIZE_TOO_LARGE_ERROR_CODE: i32 = 4;
 
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
-/// A request made to an LSP to learn what versions of the protocol they support.
-pub struct GetVersionsRequest {}
-
-/// A response to a [`GetVersionsRequest`].
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct GetVersionsResponse {
-	/// The list of versions an LSP supports.
-	pub versions: Vec<u16>,
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 /// A request made to an LSP to learn their current channel fees and parameters.
 pub struct GetInfoRequest {
-	/// What version of the protocol we want to use.
-	pub version: u16,
 	/// An optional token to provide to the LSP.
 	pub token: Option<String>,
 }
@@ -117,8 +101,6 @@ pub struct GetInfoResponse {
 /// A request to buy a JIT channel.
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct BuyRequest {
-	/// The version of the protocol to use.
-	pub version: u16,
 	/// The fee parameters you would like to use.
 	pub opening_fee_params: OpeningFeeParams,
 	/// The size of the initial payment you expect to receive.
@@ -164,8 +146,6 @@ pub struct BuyResponse {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An enum that captures all the valid JSON-RPC requests in the LSPS2 protocol.
 pub enum LSPS2Request {
-	/// A request to learn what versions an LSP supports.
-	GetVersions(GetVersionsRequest),
 	/// A request to learn an LSP's channel fees and parameters.
 	GetInfo(GetInfoRequest),
 	/// A request to buy a JIT channel from an LSP.
@@ -176,7 +156,6 @@ impl LSPS2Request {
 	/// Get the JSON-RPC method name for the underlying request.
 	pub fn method(&self) -> &str {
 		match self {
-			LSPS2Request::GetVersions(_) => LSPS2_GET_VERSIONS_METHOD_NAME,
 			LSPS2Request::GetInfo(_) => LSPS2_GET_INFO_METHOD_NAME,
 			LSPS2Request::Buy(_) => LSPS2_BUY_METHOD_NAME,
 		}
@@ -186,8 +165,6 @@ impl LSPS2Request {
 #[derive(Clone, Debug, PartialEq, Eq)]
 /// An enum that captures all the valid JSON-RPC responses in the LSPS2 protocol.
 pub enum LSPS2Response {
-	/// A successful response to a [`LSPS2Request::GetVersions`] request.
-	GetVersions(GetVersionsResponse),
 	/// A successful response to a [`LSPS2Request::GetInfo`] request.
 	GetInfo(GetInfoResponse),
 	/// An error response to a [`LSPS2Request::GetInfo`] request.

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -509,19 +509,19 @@ where
 	C::Target: Filter,
 {
 	fn transactions_confirmed(
-		&self, header: &bitcoin::block::Header, txdata: &chain::transaction::TransactionData,
-		height: u32,
+		&self, _header: &bitcoin::block::Header, _txdata: &chain::transaction::TransactionData,
+		_height: u32,
 	) {
 		// TODO: Call transactions_confirmed on all sub-modules that require it, e.g., LSPS1MessageHandler.
 	}
 
-	fn transaction_unconfirmed(&self, txid: &bitcoin::Txid) {
+	fn transaction_unconfirmed(&self, _txid: &bitcoin::Txid) {
 		// TODO: Call transaction_unconfirmed on all sub-modules that require it, e.g., LSPS1MessageHandler.
 		// Internally this should call transaction_unconfirmed for all transactions that were
 		// confirmed at a height <= the one we now unconfirmed.
 	}
 
-	fn best_block_updated(&self, header: &bitcoin::block::Header, height: u32) {
+	fn best_block_updated(&self, _header: &bitcoin::block::Header, _height: u32) {
 		// TODO: Call best_block_updated on all sub-modules that require it, e.g., LSPS1MessageHandler.
 	}
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused_imports)]
+
 #[cfg(feature = "std")]
 pub use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
 

--- a/src/sync/nostd_sync.rs
+++ b/src/sync/nostd_sync.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 //! This file was copied from `rust-lightning`.
 pub use ::alloc::sync::Arc;
 use core::cell::{Ref, RefCell, RefMut};

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -1,3 +1,6 @@
+use crate::prelude::Vec;
+use bitcoin::secp256k1::PublicKey;
+use lightning::io;
 use lightning::sign::EntropySource;
 
 pub struct TestEntropy {}
@@ -5,4 +8,51 @@ impl EntropySource for TestEntropy {
 	fn get_secure_random_bytes(&self) -> [u8; 32] {
 		[0; 32]
 	}
+}
+
+pub fn to_vec(hex: &str) -> Option<Vec<u8>> {
+	let mut out = Vec::with_capacity(hex.len() / 2);
+
+	let mut b = 0;
+	for (idx, c) in hex.as_bytes().iter().enumerate() {
+		b <<= 4;
+		match *c {
+			b'A'..=b'F' => b |= c - b'A' + 10,
+			b'a'..=b'f' => b |= c - b'a' + 10,
+			b'0'..=b'9' => b |= c - b'0',
+			_ => return None,
+		}
+		if (idx & 1) == 1 {
+			out.push(b);
+			b = 0;
+		}
+	}
+
+	Some(out)
+}
+
+pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
+	if hex.len() != 33 * 2 {
+		return None;
+	}
+	let data = match to_vec(&hex[0..33 * 2]) {
+		Some(bytes) => bytes,
+		None => return None,
+	};
+	match PublicKey::from_slice(&data) {
+		Ok(pk) => Some(pk),
+		Err(_) => None,
+	}
+}
+
+pub fn parse_pubkey(pubkey_str: &str) -> Result<PublicKey, io::Error> {
+	let pubkey = to_compressed_pubkey(pubkey_str);
+	if pubkey.is_none() {
+		return Err(io::Error::new(
+			io::ErrorKind::Other,
+			"ERROR: unable to parse given pubkey for node",
+		));
+	}
+
+	Ok(pubkey.unwrap())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,8 @@
-use bitcoin::secp256k1::PublicKey;
 use core::{fmt::Write, ops::Deref};
-use lightning::io;
 use lightning::sign::EntropySource;
 
 use crate::lsps0::msgs::RequestId;
-use crate::prelude::{String, Vec};
+use crate::prelude::String;
 
 /// Maximum transaction index that can be used in a `short_channel_id`.
 /// This value is based on the 3-bytes available for tx index.
@@ -54,53 +52,6 @@ pub fn hex_str(value: &[u8]) -> String {
 		write!(&mut res, "{:02x}", v).expect("Unable to write");
 	}
 	res
-}
-
-pub fn to_vec(hex: &str) -> Option<Vec<u8>> {
-	let mut out = Vec::with_capacity(hex.len() / 2);
-
-	let mut b = 0;
-	for (idx, c) in hex.as_bytes().iter().enumerate() {
-		b <<= 4;
-		match *c {
-			b'A'..=b'F' => b |= c - b'A' + 10,
-			b'a'..=b'f' => b |= c - b'a' + 10,
-			b'0'..=b'9' => b |= c - b'0',
-			_ => return None,
-		}
-		if (idx & 1) == 1 {
-			out.push(b);
-			b = 0;
-		}
-	}
-
-	Some(out)
-}
-
-pub fn to_compressed_pubkey(hex: &str) -> Option<PublicKey> {
-	if hex.len() != 33 * 2 {
-		return None;
-	}
-	let data = match to_vec(&hex[0..33 * 2]) {
-		Some(bytes) => bytes,
-		None => return None,
-	};
-	match PublicKey::from_slice(&data) {
-		Ok(pk) => Some(pk),
-		Err(_) => None,
-	}
-}
-
-pub fn parse_pubkey(pubkey_str: &str) -> Result<PublicKey, io::Error> {
-	let pubkey = to_compressed_pubkey(pubkey_str);
-	if pubkey.is_none() {
-		return Err(io::Error::new(
-			io::ErrorKind::Other,
-			"ERROR: unable to parse given pubkey for node",
-		));
-	}
-
-	Ok(pubkey.unwrap())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #39 
Closes #62 

As the NO VERSIONING proposal was recently merged in the spec, we here drop versioning support from LSPS2 and LSPS1.

While we're at it, we cleanup the remaining warnings emitted by `rustc`, and deny warnings for 'stable' builds in CI, which will keep us from re-introducing any new warnings and force us to handle them before merging.