### PR TITLE
LSPS2: Further client-side simplifications

### DIFF
--- a/src/lsps2/event.rs
+++ b/src/lsps2/event.rs
@@ -25,6 +25,13 @@ pub enum LSPS2ClientEvent {
 	///
 	/// [`LSPS2ClientHandler::select_opening_params`]: crate::lsps2::client::LSPS2ClientHandler::select_opening_params
 	OpeningParametersReady {
+		/// The identifier of the issued LSPS2 `get_info` request, as returned by
+		/// [`LSPS2ClientHandler::request_opening_params`]
+		///
+		/// This can be used to track which request this event corresponds to.
+		///
+		/// [`LSPS2ClientHandler::request_opening_params`]: crate::lsps2::client::LSPS2ClientHandler::request_opening_params
+		request_id: RequestId,
 		/// The node id of the LSP that provided this response.
 		counterparty_node_id: PublicKey,
 		/// The menu of fee parameters the LSP is offering at this time.

--- a/src/lsps2/event.rs
+++ b/src/lsps2/event.rs
@@ -48,13 +48,13 @@ pub enum LSPS2ClientEvent {
 	/// When the invoice is paid, the LSP will open a channel with the previously agreed upon
 	/// parameters to you.
 	InvoiceParametersReady {
-		/// A user-specified identifier used to track the channel open.
-		///
-		/// This is the same value as previously passed to
+		/// The identifier of the issued LSPS2 `buy` request, as returned by
 		/// [`LSPS2ClientHandler::select_opening_params`].
 		///
+		/// This can be used to track which request this event corresponds to.
+		///
 		/// [`LSPS2ClientHandler::select_opening_params`]: crate::lsps2::client::LSPS2ClientHandler::select_opening_params
-		user_channel_id: u128,
+		request_id: RequestId,
 		/// The node id of the LSP.
 		counterparty_node_id: PublicKey,
 		/// The intercept short channel id to use in the route hint.


### PR DESCRIPTION
We previously simplified the client-side flow and reduced the amount of superfluous tracking in #88. However, this also removed an easy way for the client to clearly associate events with the previously made requests.

In this PR we go a step further and:

a) Return the `request_id` from `request_opening_params`, re-introducing the means to associate requests/events, without the need for additional tracking of `user_channel_id`s or similar.
b) Return the `request_id` from `select_opening_params` and use it to track the requests everywhere, allowing us to drop `user_channel_id` entirely. This doesn't only mean we don't have to keep track of it separately, but also that we don't have to expose an API that might be misused, requiring us to check and document the uniqueness properties of the identifiers.
c) Since we now ended up with essentially a single client side state, we drop the `InboundChannelState` tracking entirely.
d) We commit to not support 'LSP-trusts-client' mode any time soon and just remove it from the API.