### PR TITLE
fix prepayment probing by sequencing subsequent payments

### DIFF
--- a/src/lsps2/mod.rs
+++ b/src/lsps2/mod.rs
@@ -12,5 +12,6 @@
 pub mod client;
 pub mod event;
 pub mod msgs;
+pub(crate) mod payment_queue;
 pub mod service;
 pub mod utils;

--- a/src/lsps2/payment_queue.rs
+++ b/src/lsps2/payment_queue.rs
@@ -1,0 +1,119 @@
+use crate::prelude::Vec;
+use lightning::ln::channelmanager::InterceptId;
+use lightning::ln::PaymentHash;
+
+/// Holds payments with the corresponding HTLCs until it is possible to pay the fee.
+/// When the fee is successfully paid with a forwarded payment, the queue should be consumed and the
+/// remaining payments forwarded.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) struct PaymentQueue {
+	payments: Vec<(PaymentHash, Vec<InterceptedHTLC>)>,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub(crate) struct InterceptedHTLC {
+	pub(crate) intercept_id: InterceptId,
+	pub(crate) expected_outbound_amount_msat: u64,
+	pub(crate) payment_hash: PaymentHash,
+}
+
+impl PaymentQueue {
+	pub(crate) fn new() -> PaymentQueue {
+		PaymentQueue { payments: Vec::new() }
+	}
+
+	pub(crate) fn add_htlc(&mut self, new_htlc: InterceptedHTLC) -> (u64, usize) {
+		let payment = self.payments.iter_mut().find(|(p, _)| p == &new_htlc.payment_hash);
+		if let Some((payment_hash, htlcs)) = payment {
+			// HTLCs within a payment should have the same payment hash.
+			debug_assert!(htlcs.iter().all(|htlc| htlc.payment_hash == *payment_hash));
+			// The given HTLC should not already be present.
+			debug_assert!(htlcs.iter().all(|htlc| htlc.intercept_id != new_htlc.intercept_id));
+			htlcs.push(new_htlc);
+			let total_expected_outbound_amount_msat =
+				htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum();
+			(total_expected_outbound_amount_msat, htlcs.len())
+		} else {
+			let expected_outbound_amount_msat = new_htlc.expected_outbound_amount_msat;
+			self.payments.push((new_htlc.payment_hash, vec![new_htlc]));
+			(expected_outbound_amount_msat, 1)
+		}
+	}
+
+	pub(crate) fn pop_greater_than_msat(
+		&mut self, amount_msat: u64,
+	) -> Option<(PaymentHash, Vec<InterceptedHTLC>)> {
+		let position = self.payments.iter().position(|(_payment_hash, htlcs)| {
+			htlcs.iter().map(|htlc| htlc.expected_outbound_amount_msat).sum::<u64>() >= amount_msat
+		});
+		position.map(|position| self.payments.remove(position))
+	}
+
+	pub(crate) fn clear(&mut self) -> Vec<InterceptedHTLC> {
+		self.payments.drain(..).map(|(_k, v)| v).flatten().collect()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_payment_queue() {
+		let mut payment_queue = PaymentQueue::new();
+		assert_eq!(
+			payment_queue.add_htlc(InterceptedHTLC {
+				intercept_id: InterceptId([0; 32]),
+				expected_outbound_amount_msat: 200_000_000,
+				payment_hash: PaymentHash([100; 32]),
+			}),
+			(200_000_000, 1),
+		);
+		assert_eq!(payment_queue.pop_greater_than_msat(500_000_000), None);
+
+		assert_eq!(
+			payment_queue.add_htlc(InterceptedHTLC {
+				intercept_id: InterceptId([1; 32]),
+				expected_outbound_amount_msat: 300_000_000,
+				payment_hash: PaymentHash([101; 32]),
+			}),
+			(300_000_000, 1),
+		);
+		assert_eq!(payment_queue.pop_greater_than_msat(500_000_000), None);
+
+		assert_eq!(
+			payment_queue.add_htlc(InterceptedHTLC {
+				intercept_id: InterceptId([2; 32]),
+				expected_outbound_amount_msat: 300_000_000,
+				payment_hash: PaymentHash([100; 32]),
+			}),
+			(500_000_000, 2),
+		);
+		assert_eq!(
+			payment_queue.pop_greater_than_msat(500_000_000),
+			Some((
+				PaymentHash([100; 32]),
+				vec![
+					InterceptedHTLC {
+						intercept_id: InterceptId([0; 32]),
+						expected_outbound_amount_msat: 200_000_000,
+						payment_hash: PaymentHash([100; 32]),
+					},
+					InterceptedHTLC {
+						intercept_id: InterceptId([2; 32]),
+						expected_outbound_amount_msat: 300_000_000,
+						payment_hash: PaymentHash([100; 32]),
+					},
+				]
+			))
+		);
+		assert_eq!(
+			payment_queue.clear(),
+			vec![InterceptedHTLC {
+				intercept_id: InterceptId([1; 32]),
+				expected_outbound_amount_msat: 300_000_000,
+				payment_hash: PaymentHash([101; 32]),
+			}]
+		);
+	}
+}

--- a/src/sync/nostd_sync.rs
+++ b/src/sync/nostd_sync.rs
@@ -2,12 +2,20 @@
 //! This file was copied from `rust-lightning`.
 pub use ::alloc::sync::Arc;
 use core::cell::{Ref, RefCell, RefMut};
+use core::fmt;
 use core::ops::{Deref, DerefMut};
 
 pub type LockResult<Guard> = Result<Guard, ()>;
 
 pub struct Mutex<T: ?Sized> {
 	inner: RefCell<T>,
+}
+
+impl<T: fmt::Debug> fmt::Debug for Mutex<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		let t = self.lock().unwrap();
+		fmt::Debug::fmt(t.deref(), f)
+	}
 }
 
 #[must_use = "if unused the Mutex will immediately unlock"]


### PR DESCRIPTION
This replaces the `htlcs: Vec<InterceptedHTLC>` that is stored in the OutboundJITChannelState with a map that collects htlcs grouped by PaymentHash `payments: HashMap<PaymentHash, Vec<InterceptedHTLC>>.  It also introduces a queue of payments `payment_queue: VecDeque<PaymentHash>`.  We only store the PaymentHash in the queue and can lookup the htlcs that make up the payments in the map.


When we first transition from `AwaitingPayment` to `PendingChannelOpen` we create the queue and make sure the payment hash of the htlc that triggered the transition is in the front of the queue.

When we reach ChannelReady we can pop the first payment off the queue and proceed with our normal logic of forwarding all of the HTLCs that make up that payment.

At any point in the flow if extra HTLCs come in, they will get added to the map and queue in the order they arrived.

We introduce a new public function `htlc_handling_failed` where the user can pass through the `failed_next_destination` from `HTLCHandlingFailed` events.  When we receive an `HTLCDestination::InvalidForward` we can lookup the OutboundJITChannel via the `requested_forward_scid` property.

We pop the next payment off the queue and attempt to forward it the same way we forward during ChannelReady.


It feels like there's still some issues here around subsequent payments that are different sizes.  This assumes the initial payment and subsequent ones are all the same size and therefore the same opening fee is attempted to be extracted.  This will work in the prepayment probe case we are solving for but not the general case.

To solve the general case I think we will need to store and/or recalculate both the opening fee and total amount to be forwarded based on the collected htlcs for the next payment.  

I guess we also need to handle `PaymentForwarded` events and maintain a map from ChannelId to scid so that we can forward the rest of the payment queue once we have forwarded a payment successfully.