### PR TITLE
Cut 0.1.0-alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 0.1.0-alpha - Feb. 15, 2024
+This is the first alpha release of `lighting-liquidity`. It features
+early-stage client- and service-side support for the LSPS2 just-in-time (JIT)
+channel protocol.
+
+**Note:** This release is still considered experimental, should not be run in
+production, and no compatibility guarantees are given until the release of 0.1.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "lightning-liquidity"
-version = "0.1.0"
+version = "0.1.0-alpha"
 authors = ["John Cantrell <johncantrell97@gmail.com>", "Elias Rohrer <dev@tnull.de>"]
+homepage = "https://lightningdevkit.org/"
+license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Types and primitives to integrate a spec-compliant LSP with an LDK-based node."
+repository = "https://github.com/lightningdevkit/lightning-liquidity/"
+readme = "README.md"
+keywords = ["bitcoin", "lightning", "ldk", "bdk"]
+categories = ["cryptography::cryptocurrencies"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This is the first alpha release of `lightning-liquidity`. It features early-stage client- and service-side support for the LSPS2 just-in-time (JIT) channel protocol.

