### PR TITLE
Align `rustfmt.toml` with `rust-lightning`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,12 @@
-hard_tabs = true # use tab characters for indentation, spaces for alignment
-use_field_init_shorthand = true
-max_width = 100
 use_small_heuristics = "Max"
 fn_params_layout = "Compressed"
+hard_tabs = true
+use_field_init_shorthand = true
+max_width = 100
+match_block_trailing_comma = true
+# UNSTABLE: format_code_in_doc_comments = true
+# UNSTABLE: overflow_delimited_expr = true
+# UNSTABLE: comment_width = 100
+# UNSTABLE: format_macro_matchers = true
+# UNSTABLE: format_strings = true
+# UNSTABLE: group_imports = "StdExternalCrate"

--- a/src/lsps0/client.rs
+++ b/src/lsps0/client.rs
@@ -69,7 +69,7 @@ where
 					},
 				));
 				Ok(())
-			}
+			},
 			LSPS0Response::ListProtocolsError(ResponseError { code, message, data, .. }) => {
 				Err(LightningError {
 					err: format!(
@@ -78,7 +78,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				})
-			}
+			},
 		}
 	}
 }
@@ -96,14 +96,14 @@ where
 		match message {
 			LSPS0Message::Response(_, response) => {
 				self.handle_response(response, counterparty_node_id)
-			}
+			},
 			LSPS0Message::Request(..) => {
 				debug_assert!(
 					false,
 					"Client handler received LSPS0 request message. This should never happen."
 				);
 				Err(LightningError { err: format!("Client handler received LSPS0 request message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/lsps0/ser.rs
+++ b/src/lsps0/ser.rs
@@ -222,14 +222,14 @@ impl LSPSMessage {
 		match self {
 			LSPSMessage::LSPS0(LSPS0Message::Request(request_id, request)) => {
 				Some((RequestId(request_id.0.clone()), request.into()))
-			}
+			},
 			#[cfg(lsps1)]
 			LSPSMessage::LSPS1(LSPS1Message::Request(request_id, request)) => {
 				Some((RequestId(request_id.0.clone()), request.into()))
-			}
+			},
 			LSPSMessage::LSPS2(LSPS2Message::Request(request_id, request)) => {
 				Some((RequestId(request_id.0.clone()), request.into()))
-			}
+			},
 			_ => None,
 		}
 	}
@@ -254,21 +254,21 @@ impl Serialize for LSPSMessage {
 				match request {
 					LSPS0Request::ListProtocols(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 				};
-			}
+			},
 			LSPSMessage::LSPS0(LSPS0Message::Response(request_id, response)) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
 
 				match response {
 					LSPS0Response::ListProtocols(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?;
-					}
+					},
 					LSPS0Response::ListProtocolsError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?;
-					}
+					},
 				}
-			}
+			},
 			#[cfg(lsps1)]
 			LSPSMessage::LSPS1(LSPS1Message::Request(request_id, request)) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
@@ -278,15 +278,15 @@ impl Serialize for LSPSMessage {
 				match request {
 					LSPS1Request::GetInfo(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 					LSPS1Request::CreateOrder(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 					LSPS1Request::GetOrder(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 				}
-			}
+			},
 			#[cfg(lsps1)]
 			LSPSMessage::LSPS1(LSPS1Message::Response(request_id, response)) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
@@ -294,24 +294,24 @@ impl Serialize for LSPSMessage {
 				match response {
 					LSPS1Response::GetInfo(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
+					},
 					LSPS1Response::GetInfoError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
-					}
+					},
 					LSPS1Response::CreateOrder(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
+					},
 					LSPS1Response::CreateOrderError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
-					}
+					},
 					LSPS1Response::GetOrder(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
+					},
 					LSPS1Response::GetOrderError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
-					}
+					},
 				}
-			}
+			},
 			LSPSMessage::LSPS2(LSPS2Message::Request(request_id, request)) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
 				jsonrpc_object
@@ -320,34 +320,34 @@ impl Serialize for LSPSMessage {
 				match request {
 					LSPS2Request::GetInfo(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 					LSPS2Request::Buy(params) => {
 						jsonrpc_object.serialize_field(JSONRPC_PARAMS_FIELD_KEY, params)?
-					}
+					},
 				}
-			}
+			},
 			LSPSMessage::LSPS2(LSPS2Message::Response(request_id, response)) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &request_id.0)?;
 
 				match response {
 					LSPS2Response::GetInfo(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
+					},
 					LSPS2Response::GetInfoError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
-					}
+					},
 					LSPS2Response::Buy(result) => {
 						jsonrpc_object.serialize_field(JSONRPC_RESULT_FIELD_KEY, result)?
-					}
+					},
 					LSPS2Response::BuyError(error) => {
 						jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, error)?
-					}
+					},
 				}
-			}
+			},
 			LSPSMessage::Invalid(error) => {
 				jsonrpc_object.serialize_field(JSONRPC_ID_FIELD_KEY, &serde_json::Value::Null)?;
 				jsonrpc_object.serialize_field(JSONRPC_ERROR_FIELD_KEY, &error)?;
-			}
+			},
 		}
 
 		jsonrpc_object.end()
@@ -379,22 +379,22 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 			match key {
 				"id" => {
 					id = map.next_value()?;
-				}
+				},
 				"method" => {
 					method = Some(map.next_value()?);
-				}
+				},
 				"params" => {
 					params = Some(map.next_value()?);
-				}
+				},
 				"result" => {
 					result = Some(map.next_value()?);
-				}
+				},
 				"error" => {
 					error = Some(map.next_value()?);
-				}
+				},
 				_ => {
 					let _: serde_json::Value = map.next_value()?;
-				}
+				},
 			}
 		}
 
@@ -415,7 +415,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 
 					return Err(de::Error::custom("Received unknown error message"));
 				}
-			}
+			},
 		};
 
 		match method {
@@ -432,7 +432,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						id,
 						LSPS1Request::GetInfo(request),
 					)))
-				}
+				},
 				#[cfg(lsps1)]
 				LSPSMethod::LSPS1CreateOrder => {
 					let request = serde_json::from_value(params.unwrap_or(json!({})))
@@ -441,7 +441,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						id,
 						LSPS1Request::CreateOrder(request),
 					)))
-				}
+				},
 				#[cfg(lsps1)]
 				LSPSMethod::LSPS1GetOrder => {
 					let request = serde_json::from_value(params.unwrap_or(json!({})))
@@ -450,7 +450,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						id,
 						LSPS1Request::GetOrder(request),
 					)))
-				}
+				},
 				LSPSMethod::LSPS2GetInfo => {
 					let request = serde_json::from_value(params.unwrap_or(json!({})))
 						.map_err(de::Error::custom)?;
@@ -458,12 +458,12 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						id,
 						LSPS2Request::GetInfo(request),
 					)))
-				}
+				},
 				LSPSMethod::LSPS2Buy => {
 					let request = serde_json::from_value(params.unwrap_or(json!({})))
 						.map_err(de::Error::custom)?;
 					Ok(LSPSMessage::LSPS2(LSPS2Message::Request(id, LSPS2Request::Buy(request))))
-				}
+				},
 			},
 			None => match self.request_id_to_method_map.remove(&id) {
 				Some(method) => match method {
@@ -483,7 +483,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 					#[cfg(lsps1)]
 					LSPSMethod::LSPS1GetInfo => {
 						if let Some(error) = error {
@@ -501,7 +501,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 					#[cfg(lsps1)]
 					LSPSMethod::LSPS1CreateOrder => {
 						if let Some(error) = error {
@@ -519,7 +519,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 					#[cfg(lsps1)]
 					LSPSMethod::LSPS1GetOrder => {
 						if let Some(error) = error {
@@ -537,7 +537,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 					LSPSMethod::LSPS2GetInfo => {
 						if let Some(error) = error {
 							Ok(LSPSMessage::LSPS2(LSPS2Message::Response(
@@ -554,7 +554,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 					LSPSMethod::LSPS2Buy => {
 						if let Some(error) = error {
 							Ok(LSPSMessage::LSPS2(LSPS2Message::Response(
@@ -571,7 +571,7 @@ impl<'de, 'a> Visitor<'de> for LSPSMessageVisitor<'a> {
 						} else {
 							Err(de::Error::custom("Received invalid JSON-RPC object: one of method, result, or error required"))
 						}
-					}
+					},
 				},
 				None => Err(de::Error::custom(format!(
 					"Received response for unknown request id: {}",

--- a/src/lsps0/service.rs
+++ b/src/lsps0/service.rs
@@ -49,7 +49,7 @@ impl LSPS0ServiceHandler {
 				);
 				self.pending_messages.enqueue(counterparty_node_id, msg.into());
 				Ok(())
-			}
+			},
 		}
 	}
 }
@@ -64,14 +64,14 @@ impl ProtocolMessageHandler for LSPS0ServiceHandler {
 		match message {
 			LSPS0Message::Request(request_id, request) => {
 				self.handle_request(request_id, request, counterparty_node_id)
-			}
+			},
 			LSPS0Message::Response(..) => {
 				debug_assert!(
 					false,
 					"Service handler received LSPS0 response message. This should never happen."
 				);
 				Err(LightningError { err: format!("Service handler received LSPS0 response message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/lsps1/client.rs
+++ b/src/lsps1/client.rs
@@ -62,7 +62,7 @@ impl InboundRequestState {
 		match self {
 			InboundRequestState::InfoRequested => {
 				Ok(InboundRequestState::OptionsSupport { options_supported: options })
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Received unexpected get_info response. Channel was in state: {:?}",
 				state
@@ -81,7 +81,7 @@ impl InboundRequestState {
 						options_supported, order
 					)));
 				}
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Received create order request for wrong channel. Channel was in state: {:?}",
 				state
@@ -102,7 +102,7 @@ impl InboundRequestState {
 						order, response_order
 					)))
 				}
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Received unexpected create order response. Channel was in state: {:?}",
 				state
@@ -117,7 +117,7 @@ impl InboundRequestState {
 					user_channel_id,
 					order_id: order_id.clone(),
 				})
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Received unexpected response. Channel was in state: {:?}",
 				state
@@ -158,7 +158,7 @@ impl InboundCRChannel {
 					action: ErrorAction::IgnoreAndLog(Level::Error),
 					err: "impossible state transition".to_string(),
 				});
-			}
+			},
 		}
 	}
 
@@ -293,7 +293,7 @@ where
 					Err(e) => {
 						peer_state_lock.remove_inbound_channel(user_channel_id);
 						return Err(e);
-					}
+					},
 				};
 
 				self.pending_events.enqueue(Event::LSPS1Client(LSPS1ClientEvent::GetInfoResponse {
@@ -302,7 +302,7 @@ where
 					website: result.website,
 					options_supported: result.options,
 				}))
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!(
@@ -311,7 +311,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				})
-			}
+			},
 		}
 		Ok(())
 	}
@@ -344,10 +344,10 @@ where
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					})?;
 				Ok(())
-			}
+			},
 			None => {
 				return Err(LightningError { err: format!("Received error response for a create order request from an unknown counterparty ({:?})",counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-			}
+			},
 		}
 	}
 
@@ -378,7 +378,7 @@ where
 					Err(e) => {
 						peer_state_lock.remove_inbound_channel(user_channel_id);
 						return Err(APIError::APIMisuseError { err: e.err });
-					}
+					},
 				};
 
 				let request_id = crate::utils::generate_request_id(&self.entropy_source);
@@ -392,12 +392,12 @@ where
 					)
 					.into(),
 				);
-			}
+			},
 			None => {
 				return Err(APIError::APIMisuseError {
 					err: format!("No existing state with counterparty {}", counterparty_node_id),
 				})
-			}
+			},
 		}
 		Ok(())
 	}
@@ -460,7 +460,7 @@ where
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					});
 				}
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!(
@@ -469,7 +469,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				})
-			}
+			},
 		}
 
 		Ok(())
@@ -503,10 +503,10 @@ where
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					})?;
 				Ok(())
-			}
+			},
 			None => {
 				return Err(LightningError { err: format!("Received error response for a create order request from an unknown counterparty ({:?})",counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-			}
+			},
 		}
 	}
 
@@ -547,12 +547,12 @@ where
 						err: format!("Channel with user_channel_id {} not found", user_channel_id),
 					});
 				}
-			}
+			},
 			None => {
 				return Err(APIError::APIMisuseError {
 					err: format!("No existing state with counterparty {}", counterparty_node_id),
 				})
-			}
+			},
 		}
 
 		Ok(())
@@ -585,7 +585,7 @@ where
 						),
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					})?;
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!(
@@ -594,7 +594,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				})
-			}
+			},
 		}
 
 		Ok(())
@@ -628,10 +628,10 @@ where
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					})?;
 				Ok(())
-			}
+			},
 			None => {
 				return Err(LightningError { err: format!("Received get_order response for a create order request from an unknown counterparty ({:?})",counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-			}
+			},
 		}
 	}
 }
@@ -653,22 +653,22 @@ where
 			LSPS1Message::Response(request_id, response) => match response {
 				LSPS1Response::GetInfo(params) => {
 					self.handle_get_info_response(request_id, counterparty_node_id, params)
-				}
+				},
 				LSPS1Response::GetInfoError(error) => {
 					self.handle_get_info_error(request_id, counterparty_node_id, error)
-				}
+				},
 				LSPS1Response::CreateOrder(params) => {
 					self.handle_create_order_response(request_id, counterparty_node_id, params)
-				}
+				},
 				LSPS1Response::CreateOrderError(error) => {
 					self.handle_create_order_error(request_id, counterparty_node_id, error)
-				}
+				},
 				LSPS1Response::GetOrder(params) => {
 					self.handle_get_order_response(request_id, counterparty_node_id, params)
-				}
+				},
 				LSPS1Response::GetOrderError(error) => {
 					self.handle_get_order_error(request_id, counterparty_node_id, error)
-				}
+				},
 			},
 			_ => {
 				debug_assert!(
@@ -676,7 +676,7 @@ where
 					"Client handler received LSPS1 request message. This should never happen."
 				);
 				Err(LightningError { err: format!("Client handler received LSPS1 request message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/lsps1/service.rs
+++ b/src/lsps1/service.rs
@@ -67,7 +67,7 @@ impl OutboundRequestState {
 		match self {
 			OutboundRequestState::OrderCreated { order_id } => {
 				Ok(OutboundRequestState::WaitingPayment { order_id: order_id.clone() })
-			}
+			},
 			state => Err(ChannelStateError(format!("TODO. JIT Channel was in state: {:?}", state))),
 		}
 	}
@@ -275,15 +275,15 @@ where
 								channel: None,
 							}),
 						);
-					}
+					},
 
 					_ => {
 						return Err(APIError::APIMisuseError {
 							err: format!("No pending buy request for request_id: {:?}", request_id),
 						})
-					}
+					},
 				}
-			}
+			},
 			None => {
 				return Err(APIError::APIMisuseError {
 					err: format!(
@@ -291,7 +291,7 @@ where
 						counterparty_node_id
 					),
 				})
-			}
+			},
 		}
 
 		Ok(())
@@ -337,13 +337,13 @@ where
 						order_id: params.order_id,
 					},
 				));
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!("Received error response for a create order request from an unknown counterparty ({:?})",counterparty_node_id),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				});
-			}
+			},
 		}
 
 		Ok(())
@@ -390,12 +390,12 @@ where
 						err: format!("Channel with order_id {} not found", order_id.0),
 					});
 				}
-			}
+			},
 			None => {
 				return Err(APIError::APIMisuseError {
 					err: format!("No existing state with counterparty {}", counterparty_node_id),
 				})
-			}
+			},
 		}
 		Ok(())
 	}
@@ -430,13 +430,13 @@ where
 			LSPS1Message::Request(request_id, request) => match request {
 				LSPS1Request::GetInfo(_) => {
 					self.handle_get_info_request(request_id, counterparty_node_id)
-				}
+				},
 				LSPS1Request::CreateOrder(params) => {
 					self.handle_create_order_request(request_id, counterparty_node_id, params)
-				}
+				},
 				LSPS1Request::GetOrder(params) => {
 					self.handle_get_order_request(request_id, counterparty_node_id, params)
-				}
+				},
 			},
 			_ => {
 				debug_assert!(
@@ -444,7 +444,7 @@ where
 					"Service handler received LSPS1 response message. This should never happen."
 				);
 				Err(LightningError { err: format!("Service handler received LSPS1 response message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/lsps2/client.rs
+++ b/src/lsps2/client.rs
@@ -214,7 +214,7 @@ where
 						opening_fee_params_menu: result.opening_fee_params_menu,
 					},
 				));
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!(
@@ -223,7 +223,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				})
-			}
+			},
 		}
 
 		Ok(())
@@ -248,10 +248,10 @@ where
 				}
 
 				Ok(())
-			}
+			},
 			None => {
 				return Err(LightningError { err: format!("Received error response for a get_info request from an unknown counterparty ({:?})",counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-			}
+			},
 		}
 	}
 
@@ -291,7 +291,7 @@ where
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					});
 				}
-			}
+			},
 			None => {
 				return Err(LightningError {
 					err: format!(
@@ -300,7 +300,7 @@ where
 					),
 					action: ErrorAction::IgnoreAndLog(Level::Info),
 				});
-			}
+			},
 		}
 		Ok(())
 	}
@@ -319,10 +319,10 @@ where
 				})?;
 
 				Ok(())
-			}
+			},
 			None => {
 				return Err(LightningError { err: format!("Received error response for a buy request from an unknown counterparty ({:?})", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-			}
+			},
 		}
 	}
 }
@@ -341,16 +341,16 @@ where
 			LSPS2Message::Response(request_id, response) => match response {
 				LSPS2Response::GetInfo(result) => {
 					self.handle_get_info_response(request_id, counterparty_node_id, result)
-				}
+				},
 				LSPS2Response::GetInfoError(error) => {
 					self.handle_get_info_error(request_id, counterparty_node_id, error)
-				}
+				},
 				LSPS2Response::Buy(result) => {
 					self.handle_buy_response(request_id, counterparty_node_id, result)
-				}
+				},
 				LSPS2Response::BuyError(error) => {
 					self.handle_buy_error(request_id, counterparty_node_id, error)
-				}
+				},
 			},
 			_ => {
 				debug_assert!(
@@ -358,7 +358,7 @@ where
 					"Client handler received LSPS2 request message. This should never happen."
 				);
 				Err(LightningError { err: format!("Client handler received LSPS2 request message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/lsps2/service.rs
+++ b/src/lsps2/service.rs
@@ -172,7 +172,7 @@ impl OutboundJITChannelState {
 						))
 					}
 				}
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Intercepted HTLC when JIT Channel was in state: {:?}",
 				state
@@ -187,7 +187,7 @@ impl OutboundJITChannelState {
 					htlcs: htlcs.clone(),
 					opening_fee_msat: *opening_fee_msat,
 				})
-			}
+			},
 			state => Err(ChannelStateError(format!(
 				"Channel ready received when JIT Channel was in state: {:?}",
 				state
@@ -220,7 +220,7 @@ impl OutboundJITChannel {
 			OutboundJITChannelState::AwaitingPayment { .. } => {
 				// TODO: log that we received an htlc but are still awaiting payment
 				Ok(None)
-			}
+			},
 			OutboundJITChannelState::PendingChannelOpen {
 				opening_fee_msat,
 				amt_to_forward_msat,
@@ -242,7 +242,7 @@ impl OutboundJITChannel {
 		match &self.state {
 			OutboundJITChannelState::ChannelReady { htlcs, opening_fee_msat } => {
 				Ok((htlcs.clone(), *opening_fee_msat))
-			}
+			},
 			impossible_state => Err(LightningError {
 				err: format!(
 					"Impossible state transition during channel_ready to {:?}",
@@ -332,7 +332,7 @@ where
 						});
 						self.enqueue_response(counterparty_node_id, request_id, response);
 						Ok(())
-					}
+					},
 					_ => Err(APIError::APIMisuseError {
 						err: format!(
 							"No pending get_info request for request_id: {:?}",
@@ -340,7 +340,7 @@ where
 						),
 					}),
 				}
-			}
+			},
 			None => Err(APIError::APIMisuseError {
 				err: format!("No state for the counterparty exists: {:?}", counterparty_node_id),
 			}),
@@ -374,7 +374,7 @@ where
 						});
 						self.enqueue_response(counterparty_node_id, request_id, response);
 						Ok(())
-					}
+					},
 					_ => Err(APIError::APIMisuseError {
 						err: format!(
 							"No pending get_info request for request_id: {:?}",
@@ -382,7 +382,7 @@ where
 						),
 					}),
 				}
-			}
+			},
 			None => Err(APIError::APIMisuseError {
 				err: format!("No state for the counterparty exists: {:?}", counterparty_node_id),
 			}),
@@ -434,12 +434,12 @@ where
 						);
 
 						Ok(())
-					}
+					},
 					_ => Err(APIError::APIMisuseError {
 						err: format!("No pending buy request for request_id: {:?}", request_id),
 					}),
 				}
-			}
+			},
 			None => Err(APIError::APIMisuseError {
 				err: format!("No state for the counterparty exists: {:?}", counterparty_node_id),
 			}),
@@ -482,8 +482,8 @@ where
 										intercept_scid,
 									},
 								));
-							}
-							Ok(None) => {}
+							},
+							Ok(None) => {},
 							Err(e) => {
 								self.channel_manager
 									.get_cm()
@@ -493,15 +493,15 @@ where
 									.remove(&intercept_scid);
 								// TODO: cleanup peer_by_intercept_scid
 								return Err(APIError::APIMisuseError { err: e.err });
-							}
+							},
 						}
 					}
-				}
+				},
 				None => {
 					return Err(APIError::APIMisuseError {
 						err: format!("No counterparty found for scid: {}", intercept_scid),
 					});
-				}
+				},
 			}
 		}
 
@@ -542,7 +542,7 @@ where
 										amount_to_forward_msat,
 									)?;
 								}
-							}
+							},
 							Err(e) => {
 								return Err(APIError::APIMisuseError {
 									err: format!(
@@ -550,7 +550,7 @@ where
 										e.err
 									),
 								})
-							}
+							},
 						}
 					} else {
 						return Err(APIError::APIMisuseError {
@@ -568,12 +568,12 @@ where
 						),
 					});
 				}
-			}
+			},
 			None => {
 				return Err(APIError::APIMisuseError {
 					err: format!("No counterparty state for: {}", counterparty_node_id),
 				});
-			}
+			},
 		}
 
 		Ok(())
@@ -669,7 +669,7 @@ where
 							action: ErrorAction::IgnoreAndLog(Level::Info),
 						});
 					}
-				}
+				},
 				None => {
 					self.enqueue_response(
 						counterparty_node_id,
@@ -684,7 +684,7 @@ where
 						err: "overflow error when calculating opening_fee".to_string(),
 						action: ErrorAction::IgnoreAndLog(Level::Info),
 					});
-				}
+				},
 			}
 		}
 
@@ -739,10 +739,10 @@ where
 			LSPS2Message::Request(request_id, request) => match request {
 				LSPS2Request::GetInfo(params) => {
 					self.handle_get_info_request(request_id, counterparty_node_id, params)
-				}
+				},
 				LSPS2Request::Buy(params) => {
 					self.handle_buy_request(request_id, counterparty_node_id, params)
-				}
+				},
 			},
 			_ => {
 				debug_assert!(
@@ -750,7 +750,7 @@ where
 					"Service handler received LSPS2 response message. This should never happen."
 				);
 				Err(LightningError { err: format!("Service handler received LSPS2 response message from node {:?}. This should never happen.", counterparty_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)})
-			}
+			},
 		}
 	}
 }

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -394,58 +394,58 @@ where {
 		match msg {
 			LSPSMessage::Invalid(_error) => {
 				return Err(LightningError { err: format!("{} did not understand a message we previously sent, maybe they don't support a protocol we are trying to use?", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Error)});
-			}
+			},
 			LSPSMessage::LSPS0(msg @ LSPS0Message::Response(..)) => {
 				self.lsps0_client_handler.handle_message(msg, sender_node_id)?;
-			}
+			},
 			LSPSMessage::LSPS0(msg @ LSPS0Message::Request(..)) => {
 				match &self.lsps0_service_handler {
 					Some(lsps0_service_handler) => {
 						lsps0_service_handler.handle_message(msg, sender_node_id)?;
-					}
+					},
 					None => {
 						return Err(LightningError { err: format!("Received LSPS0 request message without LSPS0 service handler configured. From node = {:?}", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-					}
+					},
 				}
-			}
+			},
 			#[cfg(lsps1)]
 			LSPSMessage::LSPS1(msg @ LSPS1Message::Response(..)) => match &self.lsps1_client_handler {
 				Some(lsps1_client_handler) => {
 					lsps1_client_handler.handle_message(msg, sender_node_id)?;
-				}
+				},
 				None => {
 					return Err(LightningError { err: format!("Received LSPS1 response message without LSPS1 client handler configured. From node = {:?}", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-				}
+				},
 			},
 			#[cfg(lsps1)]
 			LSPSMessage::LSPS1(msg @ LSPS1Message::Request(..)) => match &self.lsps1_service_handler {
 				Some(lsps1_service_handler) => {
 					lsps1_service_handler.handle_message(msg, sender_node_id)?;
-				}
+				},
 				None => {
 					return Err(LightningError { err: format!("Received LSPS1 request message without LSPS1 service handler configured. From node = {:?}", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-				}
+				},
 			},
 			LSPSMessage::LSPS2(msg @ LSPS2Message::Response(..)) => {
 				match &self.lsps2_client_handler {
 					Some(lsps2_client_handler) => {
 						lsps2_client_handler.handle_message(msg, sender_node_id)?;
-					}
+					},
 					None => {
 						return Err(LightningError { err: format!("Received LSPS2 response message without LSPS2 client handler configured. From node = {:?}", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-					}
+					},
 				}
-			}
+			},
 			LSPSMessage::LSPS2(msg @ LSPS2Message::Request(..)) => {
 				match &self.lsps2_service_handler {
 					Some(lsps2_service_handler) => {
 						lsps2_service_handler.handle_message(msg, sender_node_id)?;
-					}
+					},
 					None => {
 						return Err(LightningError { err: format!("Received LSPS2 request message without LSPS2 service handler configured. From node = {:?}", sender_node_id), action: ErrorAction::IgnoreAndLog(Level::Info)});
-					}
+					},
 				}
-			}
+			},
 		}
 		Ok(())
 	}


### PR DESCRIPTION
Now that `rust-lightning` has added `rustfmt` support, we make sure our coding style is aligned.