### PR TITLE
LSPS1: Drop `GetOrderResponse`, just use `CreateOrderResponse`

### DIFF
--- a/src/lsps1/client.rs
+++ b/src/lsps1/client.rs
@@ -12,8 +12,7 @@
 use super::event::LSPS1ClientEvent;
 use super::msgs::{
 	CreateOrderRequest, CreateOrderResponse, GetInfoRequest, GetInfoResponse, GetOrderRequest,
-	GetOrderResponse, LSPS1Message, LSPS1Request, LSPS1Response, OptionsSupported, OrderId,
-	OrderParams,
+	LSPS1Message, LSPS1Request, LSPS1Response, OptionsSupported, OrderId, OrderParams,
 };
 use super::utils::is_valid;
 use crate::message_queue::MessageQueue;
@@ -526,7 +525,7 @@ where
 	}
 
 	fn handle_get_order_response(
-		&self, request_id: RequestId, counterparty_node_id: &PublicKey, params: GetOrderResponse,
+		&self, request_id: RequestId, counterparty_node_id: &PublicKey, params: CreateOrderResponse,
 	) -> Result<(), LightningError> {
 		let outer_state_lock = self.per_peer_state.read().unwrap();
 		match outer_state_lock.get(&counterparty_node_id) {

--- a/src/lsps1/msgs.rs
+++ b/src/lsps1/msgs.rs
@@ -217,13 +217,6 @@ pub struct GetOrderRequest {
 	pub order_id: OrderId,
 }
 
-/// A response to an [`GetOrderRequest`].
-#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
-pub struct GetOrderResponse {
-	/// The response to the order request.
-	pub response: CreateOrderResponse,
-}
-
 /// An enum that captures all the valid JSON-RPC requests in the LSPS1 protocol.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum LSPS1Request {
@@ -256,7 +249,7 @@ pub enum LSPS1Response {
 	/// An error response to a [`CreateOrderRequest`].
 	CreateOrderError(ResponseError),
 	/// A successful response to a [`GetOrderRequest`].
-	GetOrder(GetOrderResponse),
+	GetOrder(CreateOrderResponse),
 	/// An error response to a [`GetOrderRequest`].
 	GetOrderError(ResponseError),
 }

--- a/src/lsps1/service.rs
+++ b/src/lsps1/service.rs
@@ -12,8 +12,8 @@
 use super::event::LSPS1ServiceEvent;
 use super::msgs::{
 	ChannelInfo, CreateOrderRequest, CreateOrderResponse, GetInfoResponse, GetOrderRequest,
-	GetOrderResponse, LSPS1Message, LSPS1Request, LSPS1Response, OptionsSupported, OrderId,
-	OrderParams, OrderPayment, OrderState, LSPS1_CREATE_ORDER_REQUEST_ORDER_MISMATCH_ERROR_CODE,
+	LSPS1Message, LSPS1Request, LSPS1Response, OptionsSupported, OrderId, OrderParams,
+	OrderPayment, OrderState, LSPS1_CREATE_ORDER_REQUEST_ORDER_MISMATCH_ERROR_CODE,
 };
 use super::utils::is_valid;
 use crate::message_queue::MessageQueue;
@@ -376,16 +376,14 @@ where
 					self.enqueue_response(
 						&counterparty_node_id,
 						request_id,
-						LSPS1Response::GetOrder(GetOrderResponse {
-							response: CreateOrderResponse {
-								order_id,
-								order: config.order.clone(),
-								order_state,
-								created_at: config.created_at,
-								expires_at: config.expires_at,
-								payment: config.payment.clone(),
-								channel,
-							},
+						LSPS1Response::GetOrder(CreateOrderResponse {
+							order_id,
+							order: config.order.clone(),
+							order_state,
+							created_at: config.created_at,
+							expires_at: config.expires_at,
+							payment: config.payment.clone(),
+							channel,
 						}),
 					)
 				} else {


### PR DESCRIPTION
Fixes #66 

The object returned as a response to a `GetOrderRequest` is the same as for `CreateOrder`. We therefore shouldn't require two objects with different serializations here. We can just drop `GetOrderResponse` and use `CreateOrderResponse`.