### PR TITLE
LSPS1: Use suitable types for `Address`es and `Bolt11Invoice`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,12 @@ categories = ["cryptography::cryptocurrencies"]
 
 [features]
 default = ["std"]
-std = ["lightning/std", "bitcoin/std"]
-no-std = ["hashbrown", "lightning/no-std", "bitcoin/no-std", "core2/alloc"]
+std = ["lightning/std", "bitcoin/std", "lightning-invoice/std"]
+no-std = ["hashbrown", "lightning/no-std", "lightning-invoice/no-std", "bitcoin/no-std", "core2/alloc"]
 
 [dependencies]
 lightning = { version = "0.0.121", default-features = false, features = ["max_level_trace"] }
-lightning-invoice = "0.29.0"
+lightning-invoice = { version = "0.29.0", default-features = false, features = ["serde"] }
 bitcoin = { version = "0.30.2", default-features = false, features = ["serde"] }
 hashbrown = { version = "0.8", optional = true }
 core2 = { version = "0.3.0", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ no-std = ["hashbrown", "lightning/no-std", "bitcoin/no-std", "core2/alloc"]
 [dependencies]
 lightning = { version = "0.0.121", default-features = false, features = ["max_level_trace"] }
 lightning-invoice = "0.29.0"
-bitcoin = { version = "0.30.2", default-features = false }
+bitcoin = { version = "0.30.2", default-features = false, features = ["serde"] }
 hashbrown = { version = "0.8", optional = true }
 core2 = { version = "0.3.0", optional = true, default-features = false }
 

--- a/src/lsps1/msgs.rs
+++ b/src/lsps1/msgs.rs
@@ -3,6 +3,8 @@
 use crate::lsps0::msgs::{LSPSMessage, RequestId, ResponseError};
 use crate::prelude::{String, Vec};
 
+use bitcoin::address::{Address, NetworkUnchecked};
+
 use serde::{Deserialize, Serialize};
 
 use chrono::Utc;
@@ -94,7 +96,7 @@ pub struct OrderParams {
 	/// May contain arbitrary associated data like a coupon code or a authentication token.
 	pub token: String,
 	/// The address where the LSP will send the funds if the order fails.
-	pub refund_onchain_address: Option<String>,
+	pub refund_onchain_address: Option<Address<NetworkUnchecked>>,
 	/// Indicates if the channel should be announced to the network.
 	pub announce_channel: bool,
 }
@@ -142,7 +144,7 @@ pub struct OrderPayment {
 	pub bolt11_invoice: String,
 	/// An on-chain address the client can send [`Self::order_total_sat`] to to have the channel
 	/// opened.
-	pub onchain_address: String,
+	pub onchain_address: Address<NetworkUnchecked>,
 	/// The minimum number of block confirmations that are required for the on-chain payment to be
 	/// considered confirmed.
 	pub min_onchain_payment_confirmations: Option<u8>,

--- a/src/lsps1/msgs.rs
+++ b/src/lsps1/msgs.rs
@@ -5,6 +5,8 @@ use crate::prelude::{String, Vec};
 
 use bitcoin::address::{Address, NetworkUnchecked};
 
+use lightning_invoice::Bolt11Invoice;
+
 use serde::{Deserialize, Serialize};
 
 use chrono::Utc;
@@ -141,7 +143,7 @@ pub struct OrderPayment {
 	/// What the client needs to pay in total to open the requested channel.
 	pub order_total_sat: u64,
 	/// A BOLT11 invoice the client can pay to have to channel opened.
-	pub bolt11_invoice: String,
+	pub bolt11_invoice: Bolt11Invoice,
 	/// An on-chain address the client can send [`Self::order_total_sat`] to to have the channel
 	/// opened.
 	pub onchain_address: Address<NetworkUnchecked>,

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -286,7 +286,68 @@ where {
 	/// ```
 	///
 	/// [`PeerManager::process_events`]: lightning::ln::peer_handler::PeerManager::process_events
+	#[cfg(feature = "std")]
 	pub fn set_process_msgs_callback(&self, callback: impl Fn() + Send + Sync + 'static) {
+		self.pending_messages.set_process_msgs_callback(callback)
+	}
+
+	/// Allows to set a callback that will be called after new messages are pushed to the message
+	/// queue.
+	///
+	/// Usually, you'll want to use this to call [`PeerManager::process_events`] to clear the
+	/// message queue. For example:
+	///
+	/// ```
+	/// # use lightning::io;
+	/// # use lightning_liquidity::LiquidityManager;
+	/// # use std::sync::{Arc, RwLock};
+	/// # use std::sync::atomic::{AtomicBool, Ordering};
+	/// # use std::time::SystemTime;
+	/// # struct MyStore {}
+	/// # impl lightning::util::persist::KVStore for MyStore {
+	/// #     fn read(&self, primary_namespace: &str, secondary_namespace: &str, key: &str) -> io::Result<Vec<u8>> { Ok(Vec::new()) }
+	/// #     fn write(&self, primary_namespace: &str, secondary_namespace: &str, key: &str, buf: &[u8]) -> io::Result<()> { Ok(()) }
+	/// #     fn remove(&self, primary_namespace: &str, secondary_namespace: &str, key: &str, lazy: bool) -> io::Result<()> { Ok(()) }
+	/// #     fn list(&self, primary_namespace: &str, secondary_namespace: &str) -> io::Result<Vec<String>> { Ok(Vec::new()) }
+	/// # }
+	/// # struct MyEntropySource {}
+	/// # impl lightning::sign::EntropySource for MyEntropySource {
+	/// #     fn get_secure_random_bytes(&self) -> [u8; 32] { [0u8; 32] }
+	/// # }
+	/// # struct MyEventHandler {}
+	/// # impl MyEventHandler {
+	/// #     async fn handle_event(&self, _: lightning::events::Event) {}
+	/// # }
+	/// # #[derive(Eq, PartialEq, Clone, Hash)]
+	/// # struct MySocketDescriptor {}
+	/// # impl lightning::ln::peer_handler::SocketDescriptor for MySocketDescriptor {
+	/// #     fn send_data(&mut self, _data: &[u8], _resume_read: bool) -> usize { 0 }
+	/// #     fn disconnect_socket(&mut self) {}
+	/// # }
+	/// # type MyBroadcaster = dyn lightning::chain::chaininterface::BroadcasterInterface;
+	/// # type MyFeeEstimator = dyn lightning::chain::chaininterface::FeeEstimator;
+	/// # type MyNodeSigner = dyn lightning::sign::NodeSigner;
+	/// # type MyUtxoLookup = dyn lightning::routing::utxo::UtxoLookup;
+	/// # type MyFilter = dyn lightning::chain::Filter;
+	/// # type MyLogger = dyn lightning::util::logger::Logger;
+	/// # type MyChainMonitor = lightning::chain::chainmonitor::ChainMonitor<lightning::sign::InMemorySigner, Arc<MyFilter>, Arc<MyBroadcaster>, Arc<MyFeeEstimator>, Arc<MyLogger>, Arc<MyStore>>;
+	/// # type MyPeerManager = lightning::ln::peer_handler::SimpleArcPeerManager<MySocketDescriptor, MyChainMonitor, MyBroadcaster, MyFeeEstimator, Arc<MyUtxoLookup>, MyLogger>;
+	/// # type MyNetworkGraph = lightning::routing::gossip::NetworkGraph<Arc<MyLogger>>;
+	/// # type MyGossipSync = lightning::routing::gossip::P2PGossipSync<Arc<MyNetworkGraph>, Arc<MyUtxoLookup>, Arc<MyLogger>>;
+	/// # type MyChannelManager = lightning::ln::channelmanager::SimpleArcChannelManager<MyChainMonitor, MyBroadcaster, MyFeeEstimator, MyLogger>;
+	/// # type MyScorer = RwLock<lightning::routing::scoring::ProbabilisticScorer<Arc<MyNetworkGraph>, Arc<MyLogger>>>;
+	/// # type MyLiquidityManager = LiquidityManager<Arc<MyEntropySource>, Arc<MyChannelManager>, Arc<MyFilter>>;
+	/// # fn setup_background_processing(my_persister: Arc<MyStore>, my_event_handler: Arc<MyEventHandler>, my_chain_monitor: Arc<MyChainMonitor>, my_channel_manager: Arc<MyChannelManager>, my_logger: Arc<MyLogger>, my_peer_manager: Arc<MyPeerManager>, my_liquidity_manager: Arc<MyLiquidityManager>) {
+	/// let process_msgs_pm = Arc::clone(&my_peer_manager);
+	/// let process_msgs_callback = move || process_msgs_pm.process_events();
+	///
+	/// my_liquidity_manager.set_process_msgs_callback(process_msgs_callback);
+	/// # }
+	/// ```
+	///
+	/// [`PeerManager::process_events`]: lightning::ln::peer_handler::PeerManager::process_events
+	#[cfg(feature = "no-std")]
+	pub fn set_process_msgs_callback(&self, callback: impl Fn() + 'static) {
 		self.pending_messages.set_process_msgs_callback(callback)
 	}
 


### PR DESCRIPTION
Fixes #64 

We now use `bitcoin::Address` and `Bolt11Invoice` types in LSPS1 instead of Strings.