### PR TITLE
Cut v0.1.0-alpha.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
+# 0.1.0-alpha.1 - Feb. 28, 2024
+This is the second alpha release of `lightning-liquidity`. It features
+a number of bug fixes and performance improvements over the previous release.
+
+**Note:** This release is still considered experimental, should not be run in
+production, and no compatibility guarantees are given until the release of 0.1.0.
+
 # 0.1.0-alpha - Feb. 15, 2024
 This is the first alpha release of `lightning-liquidity`. It features
 early-stage client- and service-side support for the LSPS2 just-in-time (JIT)
 channel protocol.
 
 **Note:** This release is still considered experimental, should not be run in
-production, and no compatibility guarantees are given until the release of 0.1.
+production, and no compatibility guarantees are given until the release of 0.1.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lightning-liquidity"
-version = "0.1.0-alpha"
+version = "0.1.0-alpha.1"
 authors = ["John Cantrell <johncantrell97@gmail.com>", "Elias Rohrer <dev@tnull.de>"]
 homepage = "https://lightningdevkit.org/"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
We cut the second alpha release of `lightning-liquidity`. It features a number of bug fixes and performance improvements over the previous release.