### PR TITLE
LSPS2: check and return if fee has been skimmed

### DIFF
--- a/src/lsps2/payment_queue.rs
+++ b/src/lsps2/payment_queue.rs
@@ -49,8 +49,8 @@ impl PaymentQueue {
 		position.map(|position| self.payments.remove(position))
 	}
 
-	pub(crate) fn clear(&mut self) -> Vec<InterceptedHTLC> {
-		self.payments.drain(..).map(|(_k, v)| v).flatten().collect()
+	pub(crate) fn clear(&mut self) -> Vec<(PaymentHash, Vec<InterceptedHTLC>)> {
+		self.payments.drain(..).collect()
 	}
 }
 
@@ -109,11 +109,14 @@ mod tests {
 		);
 		assert_eq!(
 			payment_queue.clear(),
-			vec![InterceptedHTLC {
-				intercept_id: InterceptId([1; 32]),
-				expected_outbound_amount_msat: 300_000_000,
-				payment_hash: PaymentHash([101; 32]),
-			}]
+			vec![(
+				PaymentHash([101; 32]),
+				vec![InterceptedHTLC {
+					intercept_id: InterceptId([1; 32]),
+					expected_outbound_amount_msat: 300_000_000,
+					payment_hash: PaymentHash([101; 32]),
+				}]
+			)]
 		);
 	}
 }


### PR DESCRIPTION
Based on #137 and #135 

Using skimmed_fee_msat in the payment forwarded event we should actually check to make sure the we have skimmed the correct amount of fees.

I subtract the skimmed fee from the expected fee to get a remaining fee.  If remaining fee is 0 then the logic continues as before.

If the remaining fee is > 0 then it basically performs the htlc_handling_failed logic but uses the remaining fee as the expected fee.  This is likely outside of the spec and should in theory never happen since we check to make sure we can skim the entire fee before attempting the forward in the first place.

I also updated the payment_forwarded function to return a boolean for whether or not the channel has been sufficiently paid for so the LSP can use the response to determine if it should release a held funding tx when using client trusts lsp.