### PR TITLE
LSPS2: ability to signal channel open failure

### DIFF
--- a/src/lsps2/payment_queue.rs
+++ b/src/lsps2/payment_queue.rs
@@ -49,8 +49,8 @@ impl PaymentQueue {
 		position.map(|position| self.payments.remove(position))
 	}
 
-	pub(crate) fn clear(&mut self) -> Vec<InterceptedHTLC> {
-		self.payments.drain(..).map(|(_k, v)| v).flatten().collect()
+	pub(crate) fn clear(&mut self) -> Vec<(PaymentHash, Vec<InterceptedHTLC>)> {
+		self.payments.drain(..).collect()
 	}
 }
 
@@ -109,11 +109,14 @@ mod tests {
 		);
 		assert_eq!(
 			payment_queue.clear(),
-			vec![InterceptedHTLC {
-				intercept_id: InterceptId([1; 32]),
-				expected_outbound_amount_msat: 300_000_000,
-				payment_hash: PaymentHash([101; 32]),
-			}]
+			vec![(
+				PaymentHash([101; 32]),
+				vec![InterceptedHTLC {
+					intercept_id: InterceptId([1; 32]),
+					expected_outbound_amount_msat: 300_000_000,
+					payment_hash: PaymentHash([101; 32]),
+				}]
+			)]
 		);
 	}
 }


### PR DESCRIPTION
Closes https://github.com/lightningdevkit/rust-lightning/issues/3479

There are a number of reasons a channel open might fail or be abandoned by the LSP. This adds a way for the LSP to signal back to the library that this has happened.

All pending payments are failed backwards and the channel state is reset to PendingInitialPayment as per the spec. This allows the payer to try again.