### PR TITLE
error on htlc_intercepted for unknown scid

### DIFF
--- a/src/lsps2/service.rs
+++ b/src/lsps2/service.rs
@@ -763,6 +763,10 @@ where
 					});
 				},
 			}
+		} else {
+			return Err(APIError::APIMisuseError {
+				err: format!("Unknown scid provided: {}", intercept_scid),
+			});
 		}
 
 		Ok(())


### PR DESCRIPTION
Currently we return Ok(()) if the intercept_scid is unknown which means upstream users won't know that we didn't know about this SCID and the intercepted htlc will be stuck until expiry.

We should signal Error for unknown scid's so upstream users can fail back if there's no other reason for the intercepted htlc.