### PR TITLE
Remove max_level_trace feature on lightning package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ std = ["lightning/std", "bitcoin/std", "lightning-invoice/std"]
 no-std = ["hashbrown", "lightning/no-std", "lightning-invoice/no-std", "bitcoin/no-std", "core2/alloc"]
 
 [dependencies]
-lightning = { version = "0.0.123", default-features = false, features = ["max_level_trace"] }
+lightning = { version = "0.0.123", default-features = false }
 lightning-invoice = { version = "0.31.0", default-features = false, features = ["serde"] }
 bitcoin = { version = "0.30.2", default-features = false, features = ["serde"] }
 hashbrown = { version = "0.8", optional = true }
@@ -30,7 +30,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "allo
 serde_json = "1.0"
 
 [dev-dependencies]
-lightning = { version = "0.0.123", default-features = false, features = ["max_level_trace", "_test_utils"] }
+lightning = { version = "0.0.123", default-features = false, features = ["_test_utils"] }
 lightning-persister = { version = "0.0.123", default-features = false }
 lightning-background-processor = { version = "0.0.123", default-features = false, features = ["std"] }
 proptest = "1.0.0"


### PR DESCRIPTION
Cargo resolves dependencies with the union of all features enabled on them. Setting the max_level_trace feature stops any consumers from emitting gossip logs.